### PR TITLE
Consolidate PR feedback and add Alessandro as author

### DIFF
--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -44,7 +44,7 @@ venue:
 
 Encrypted ClientHello (ECH) requires clients to have the server's ECH configuration before connecting. Currently, when ECH fails, servers can send updated configurations but clients cannot authenticate them unless the server has a valid certificate for the public name, limiting deployment flexibility.
 
-This document specifies a new mechanism for authenticating ECH configurations. Servers include additional information in their initial ECH configurations, which enables clients to authenticate any updated configurations without relying on a valid certificate for the public name.
+This document specifies a new mechanism for authenticating ECH configurations. Servers include additional information in their initial ECH configurations, which enables clients to authenticate updated configurations without relying on a valid certificate for the public name.
 
 --- middle
 
@@ -281,7 +281,7 @@ During the TLS handshake, upon receiving an ECHConfigList in EE:
      * The client MUST NOT use the retry_configs
      * The client terminates the connection without retry
 
-Note: Regardless of validation outcome in an ECH rejection, the client will terminate the current connection. The difference is whether it retries with the new configs (validation success) or treats it as a certificate validation failure (validation failure). Implementers should refer to the state diagram in Appendix A for the complete retry logic flow.
+Note: Regardless of validation outcome in an ECH rejection, the client will terminate the current connection. The difference is whether it retries with the new configs (validation success) or treats it as a certificate validation failure (validation failure).
 
 ### Backward Compatibility
 
@@ -330,7 +330,7 @@ ECHConfigs delivered in EncryptedExtensions are usually protected by TLS 1.3's h
 
 However, signed ECHConfigs don't benefit from this authentication because the client does not validate the server's certificate chain. Instead, the client verifies the ECHConfigs against the authenticator provided in the initial ECHConfig. This provides the same level of authenticity as checking the ECH Public Name would.
 
-he inclusion of `not_after` timestamps (for RPK) or certificate validity periods (for PKIX) ensures configuration freshness. These temporal bounds prevent clients from accepting stale configurations that might use compromised keys or otherwise parameters. ECH providers should use a window of 24 hours.
+The inclusion of `not_after` timestamps (for RPK) or certificate validity periods (for PKIX) ensures configuration freshness. These temporal bounds prevent clients from accepting stale configurations that might use compromised keys or otherwise parameters. ECH providers should use a window of 24 hours.
 
 ### Key Management
 
@@ -348,7 +348,7 @@ Algorithm agility is provided through the TLS SignatureScheme registry for RPK a
 
 ### Denial of Service Considerations
 
-The ECH Specification allows ECH Operators to decide which ECH extensions to attempt to decrypt based on the public ECHConfig ID advertised in the Client Hello and the public SNI name. This extension reduces the value of that signal, meaning that ECH operators will need to be willing to trial decrypt incoming ECH extensions. This is not a substantial burden, should be accounted for when provisioning these signed configs.
+The ECH Specification allows ECH Operators to decide which ECH extensions to attempt to decrypt based on the public ECHConfig ID advertised in the Client Hello and the public name. This extension reduces the value of thoses signals, depending on the ECH operator's chosen configurations, meaning that ECH operators may need to trial decrypt incoming ECH extensions.
 
 Attackers cannot force servers to send signed ECHConfigs without establishing TLS connections. Standard TLS denial-of-service mitigations (rate limiting, stateless cookies) apply equally to this mechanism.
 

--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -42,9 +42,9 @@ venue:
 
 --- abstract
 
-Encrypted ClientHello (ECH) requires clients to have the server's ECH configuration before connecting. Currently, when ECH fails, servers can send updated configurations but clients cannot authenticate them without a certificate for the public name, limiting deployment flexibility.
+Encrypted ClientHello (ECH) requires clients to have the server's ECH configuration before connecting. Currently, when ECH fails, servers can send updated configurations but clients cannot authenticate them unless the server has a valid certificate for the public name, limiting deployment flexibility.
 
-This document specifies an authenticated ECH configuration update mechanism. Servers can deliver signed ECH configurations during the TLS handshake, allowing clients to authenticate and immediately use them for retry. The mechanism decouples ECH key distribution from transport, enabling the same signed configuration to work via DNS or TLS delivery.
+This document specifies a new mechanism for authenticating ECH configurations. Servers include additional information in their initial ECH configurations, which enables clients to authenticate any updated configurations without relying on a valid certificate for the public name.
 
 --- middle
 
@@ -52,18 +52,18 @@ This document specifies an authenticated ECH configuration update mechanism. Ser
 
 Deployment of TLS Encrypted ClientHello (ECH) requires that clients obtain the server's current ECH configuration (ECHConfig) before initiating a connection. Current mechanisms distribute ECHConfig data via DNS HTTPS resource records {{!RFC9460}} or HTTPS well-known URIs {{!I-D.ietf-tls-wkech}}, allowing servers to publish their ECHConfigList prior to connection establishment.
 
-While ECH includes a retry mechanism where servers can send updated ECHConfigList values during the handshake (via HelloRetryRequest or EncryptedExtensions), the base ECH specification instructs clients not to cache these configurations {{!I-D.ietf-tls-esni}}. Instead, servers must authenticate the outer handshake using a certificate for the public name, and clients must obtain updated configurations through out-of-band mechanisms for future connections.
+ECH includes a retry mechanism where servers can send an updated ECHConfigList during the handshake, the base ECH specification instructs clients to authenticate this information using a certificate valid for the public name {{!I-D.ietf-tls-esni}}.
 
-This approach limits ECH deployment in two key ways. First, it restricts the usable public names to those for which operators can obtain certificates, reducing the potential anonymity set. Second, it creates delays in key rotation recovery, as clients cannot immediately use updated configurations received during the handshake.
+This forces a tradeoff between security and privacy for server operators. Using the same public name for as many websites as possible improves client privacy, but makes obtaining or compromising a valid certificate for that cover name a high value target for attackers. It also restricts the usable public names in an ECH deployment to those for which operators can obtain valid certificates.
 
-This document introduces an Authenticated ECH Config Update mechanism to securely deliver and rotate ECHConfig data in-band, during a TLS handshake. The goal is to allow servers to frequently update ECH keys (for example, to limit the lifetime of keys or respond to compromise). This mechanism does not prescribe or rely on fallback to cleartext; when ECH fails with this mechanism, the connection is terminated and retried with updated configurations rather than exposing the protected name.
+This document introduces an alternative authentication mechanism for ECHConfig data which doesn't rely on the public name used in the initial ECHConfig. This allows server operators to partition the retry configuration between different domains, as well as enabling a greater flexibility in the public name used.
 
-The mechanism supports two authentication methods through the `ech_auth` ECHConfig extension:
+The mechanism supports two authentication methods:
 
-1. Raw Public Key (RPK) - SPKI hashing for configuration-specific trust
-2. PKIX - Certificate-based signing with a critical X.509 extension
+1. Raw Public Key (RPK) - Uses SPKI hashes to identify public keys for retry authentication.
+2. PKIX - Uses certificate-based signing with a critical X.509 extension.
 
-Each ECHConfig carries at most one signature using the specified method. By authenticating ECH configs independently, the mechanism makes ECH key distribution orthogonal to transport. The same signed ECHConfig artifact can be conveyed via DNS, HTTPS, or the TLS handshake itself. The client will accept it only if the accompanying signature or proof is valid under one of its trust modes.
+Each ECH Retry Configuration carries at most one signature using the specified method, replacing the need to authenticate the ECH Retry configuration through the TLS handshake and ECH Public Name.
 
 # Conventions and Definitions
 
@@ -78,8 +78,6 @@ The following acronyms are used throughout this document:
 - SPKI: SubjectPublicKeyInfo - The ASN.1 structure containing a public key and its algorithm identifier
 - HPKE: Hybrid Public Key Encryption - The encryption scheme used by ECH as defined in {{!RFC9180}}
 - DER: Distinguished Encoding Rules - A binary encoding format for ASN.1 structures
-- OCSP: Online Certificate Status Protocol - A method for checking certificate revocation status
-- CRL: Certificate Revocation List - A list of revoked certificates published by a Certificate Authority
 - CA: Certificate Authority - An entity that issues digital certificates
 
 ## Terminology
@@ -93,14 +91,14 @@ ECHConfigList:
 ECHConfigTBS (To-Be-Signed):
 : The serialized ECHConfig structure with the `ech_auth` extension, but with the `signature` field within `ech_auth` set to zero-length. This includes all ECHConfig fields and the `ech_auth` extension's `method` and `trusted_keys` fields.
 
-authenticated ECHConfig:
+signed ECHConfig:
 : An ECHConfig that contains an `ech_auth` extension with a valid signature in the `signature` field, allowing clients to verify its authenticity.
 
 public name:
 : The value of the `public_name` field in the ECHConfig, i.e., the authoritative DNS name for updates and validation associated with that configuration. This name is not required to be the ClientHelloOuter SNI, though deployments sometimes choose to align them.
 
 retry_configs:
-: The ECHConfigList sent by a server in HelloRetryRequest or EncryptedExtensions when ECH is rejected, as defined in {{!I-D.ietf-tls-esni}}.
+: The ECHConfigList sent by a server in EncryptedExtensions when ECH is rejected, as defined in {{!I-D.ietf-tls-esni}}.
 
 outer SNI:
 : The Server Name Indication value sent in the outer (unencrypted) ClientHello when ECH is used. This is typically the ECHConfig's `public_name` or another name that preserves client privacy.
@@ -109,35 +107,37 @@ The reader should recall that in TLS 1.3, the server's EncryptedExtensions messa
 
 # Mechanism Overview
 
-This specification defines three methods for authenticating ECH configuration updates:
+This specification defines two methods for authenticating ECH configuration updates:
+
+Raw Public Keys (RPK) has little wire overhead and no external dependencies. The site offering ECH places one or more public key hashes in their ECH Configs, then can use those keys to sign ECH Retry Configs. However, key rotation must be managed by the site operator, through updates to the list of trusted public key hashes.
+
+PKIX has a larger wire overhead and requires coordination with an issuing CA - who must provide certificates with an appropriate extension. However, it doesn't require any manual key rotation. The public name used to authenticate the certificate is a fixed string, which is never visible on the wire, and the operator can rotate certificate chains without any needing to change their advertised ECHConfigs.
 
 ## Raw Public Key (RPK)
 
-The ECHConfigList update is authenticated by a Raw Public Key (RPK). The ECHConfig's `ech_auth` extension carries a set of `trusted_keys`, each value being `SHA-256(SPKI)` of an RPK that is authorized to sign an update.
+The ECHConfigList update is authenticated by a Raw Public Key (RPK). The ECHConfig's `ech_authinfo` extension carries a set of `trusted_keys`, each value being `SHA-256(SPKI)` of an RPK that is authorized to sign an update.
 
-A client receiving an authenticated update (e.g., in HRR/EE `retry_configs`) MUST:
+A client receiving a signed ECH retry configuration (e.g., in Encrypted Extensions) MUST:
 
 1. Extract the authenticator key's SubjectPublicKeyInfo (SPKI) and compute `sha256(spki)`. Verify membership in `trusted_keys`.
 2. Verify that `not_after` is strictly greater than the client's current time.
-3. Verify the signature over the `to_be_signed` input using the authenticator key.
+3. Verify the signature over the ECH Configuration and the `not_after` using the authenticator's public key.
 
-Clients MAY cache `trusted_keys` only for the lifetime of the associated ECHConfig and solely to authenticate a single retry-configs update per fresh connection attempt. Upon successful installation of a new ECHConfigList (via an authenticated update or a fresher out-of-band fetch), or upon expiration of the cached configuration, clients MUST clear any RPK state learned from the prior configuration.
-
-This specification defines no long-term pinning and no public-name authentication via RPK.
+The client may then use the signed ECH retry configuration to make a new connection attempt, in line with the existing rules for ECH retrys laid out in the ECH specification. Alternatively, if the server wants the client to disable ECH then it can produce a signature over an empty ECHConfig to indicate that.
 
 ## PKIX (Certificate-Based)
 
-The update is signed with the private key corresponding to an X.509 certificate that chains to a locally trusted root and is valid for the ECHConfig `public_name` (i.e., appears in the certificate's SAN).
+The update is signed with the private key corresponding to an X.509 certificate that chains to a client trusted root and is valid for the ECHConfig `public_name` (i.e., appears in the certificate's SAN).
 
 The leaf certificate MUST include a new, critical X.509 v3 extension `id-pe-echConfigSigning` (OID: TBD) whose presence indicates authorization to sign ECH configuration updates for the DNS names in the certificate's SAN. Clients:
 
 - MUST validate the certificate chain according to local policy;
 - MUST confirm the SAN covers the ECHConfig `public_name`;
 - MUST confirm the critical `id-pe-echConfigSigning` extension is present in the leaf; and
-- MUST verify the ECH update signature with the leaf key.
+- MUST verify the ECH signature with the leaf key.
+- MUST verify that the `not_after` field in `ech_auth.signature` is strictly greater than the client's current time.
 
-When this critical extension is present, clients MUST NOT accept the certificate for TLS server authentication. The `not_after` field in `ech_auth.signature` MUST be 0 for PKIX.
-
+When this critical extension is present, clients MUST NOT accept the certificate for TLS server authentication. The use of a the critical bit ensures that even clients who are unaware of the extension, will not accept it for TLS server authentication.
 
 # Benefits of Signed ECH Configurations
 
@@ -145,36 +145,27 @@ By treating ECH configurations as signed objects, this mechanism decouples trust
 
 ## Distinct Public Names Without CA Certificates
 
-A server can use many different public hostnames (even per-client, per-connection unique ones) to maximize the anonymity set or for other operational reasons {{!I-D.ietf-tls-esni}}, without having to obtain certificates for each. The RPK method allows the client to authenticate the server's ability to update ECH keys for those public names via a key hash, rather than via a CA-issued certificate. This was not possible under the original ECH design, which required a valid certificate for any public name used {{!I-D.ietf-tls-esni}}.
+A server can use many different public hostnames (even per-client, per-connection unique ones) for other operational reasons {{!I-D.ietf-tls-esni}}, without having to obtain certificates for each. This was not possible under the original ECH design, which required a valid certificate for any public name used {{!I-D.ietf-tls-esni}}.
 
-## Faster and Safer Key Rotation
+## Isolating privacy-critical key material
 
-The server can proactively push a new ECHConfig to clients shortly before rotating keys, ensuring clients receive it immediately. The update objects include an expiration timestamp (`not_after`), allowing servers to bound the lifetime of configurations to coordinate key rollover. Clients will reject expired configurations.
-
-## Out-of-Band Distribution Synergy
-
-Because the same authentication methods are defined for in-band and out-of-band, an ECHConfig obtained via DNS can carry the same signature that a TLS in-band update would, allowing clients to verify it even if their DNS channel is not fully trusted. For instance, a client might obtain an ECHConfig via DNS; if that ECHConfig has RPK trusted_keys, subsequent updates via TLS will be signed by that key, protecting against any earlier undetected DNS tampering.
-
-## Design Simplicity
-
-This design attempts to minimize complexity. It does not use explicit key identifiers or complicated pin rotation metadata. For the RPK method, the pinning model is kept simple (a list of allowed signing keys established from an authenticated initial configuration); pin revocation or addition is handled by simply signing a new update that changes the list (clients trust the new list if it is signed by a currently trusted key). There is no "next update time" field that requires clients to preemptively fetch updates; instead, updates are fetched when provided by the server or when the client next connects. The mechanism is agnostic to the transport by which the client obtained the initial ECHConfig – whether via DNS SVCB/HTTPS RR (as in {{!I-D.ietf-tls-svcb-ech}}), via a well-known HTTPS endpoint {{!I-D.ietf-tls-wkech}}, or via some provisioning protocol, the subsequent updates use the same verification process.
+In a large CDN deployment, the ECH specification requires many endpoints to have access to key material which can authenticate a TLS connection for the ECH Cover Name. This raises privacy and security risks - where compromise of the private key material in turn compromises the privacy of ECH users and the security of normal TLS connections to the cover name. Both the mechanisms introduced in this document avoid this problematic sharing of private key material, reducing the risk for ECH operators.
 
 # Protocol Elements {#wire-formats}
 
 This section specifies the new extensions and data structures in detail. All multi-byte values are in network byte order (big-endian). The syntax uses the TLS presentation language from {{!RFC8446}}.
 
-## ECH authentication extension (`ech_auth`)
+## ECH authentication extensions (`ech_auth`)
 
-The `ech_auth` information is carried as an ECHConfig extension inside the ECHConfig structure and is used both when distributed via DNS and when delivered in TLS (HRR/EE) as part of `retry_configs`. This single extension conveys policy (which signature methods and pins are supported) and, when present, a signed authenticator that allows clients to verify and install the ECHConfig immediately.
+The information for authenticating retry configs is carried as an ECHConfig extension (`ech_authinfo`) inside the ECHConfig structure and conveys authentication policy. ECH Retry Configs include an `ech_auth` extension which includes signed authenticator that allows clients to verify the provided config independently of the TLS handshake.
 
 The `ech_auth` extension MUST be the last extension in the ECHConfig's extension list. This ensures that the signature in the extension covers all other extensions in the ECHConfigTBS. Implementations MUST place this extension last when constructing an ECHConfig, and MUST reject ECHConfigs where `ech_auth` is not the last extension.
 
-The `ech_auth` extension has the following structure:
+The `ech_auth` and`ech_authinfo` extensions have the following structure:
 
     enum {
-        none(0),
-        rpk(1),
-        pkix(2),
+        rpk(0),
+        pkix(1),
         (255)
     } ECHAuthMethod;
 
@@ -186,20 +177,16 @@ The `ech_auth` extension has the following structure:
 struct {
       ECHAuthMethod method;              // Single authentication method
       SPKIHash trusted_keys<0..2^16-1>;  // RPK-only; SHA-256 hashes per IANA TLS
-                                          // HashAlgorithm registry value 4;
-                                          // zero-length if method != rpk
+    } ECHAuthInfo;
 
-      // Optional signed authenticator. Present when the sender wishes
-      // to provide a signed ECHConfig (e.g., in TLS retry_configs, or
-      // pre-signed in DNS).
-struct {
-        opaque authenticator<1..2^16-1>; // method-specific material (see below)
-        uint64 not_after;                 // Unix timestamp; used by RPK;
-                                          // MUST be 0 for PKIX
-SignatureScheme algorithm;
+  struct {
+    ECHAuth method
+    uint64 not_after;
+    opaque authenticator<1..2^16-1>; //Holds either RPK DER or PKIX certificate
+    SignatureScheme algorithm;
         opaque signature<1..2^16-1>;
-      } signature;                        // Optional; zero-length if not present
-    } ECHAuth;
+      } signature;
+  } ECHAuth
 
 ### Signature Computation
 
@@ -215,75 +202,64 @@ where:
   set to zero-length. This means it includes:
   - All ECHConfig base fields (version, length, contents, etc.)
   - All extensions including `ech_auth` (which MUST be last)
-  - Within `ech_auth`: the `method`, `trusted_keys`, and the authenticator/
+  - Within `ech_auth`: the `method`, and the authenticator/
     not_after/algorithm fields from `signature`, but NOT the actual signature
     bytes
-- The signature is computed over this entire structure, avoiding circular
-  dependency by zeroing out only the signature bytes themselves
+- The signature is computed over this entire structure.
 - All multi-byte values use network byte order (big-endian)
 - The serialization follows TLS 1.3 presentation language rules from RFC 8446
 
-Including a fixed, scheme-specific context label prevents cross-protocol reuse; covering the to-be-signed ECHConfig and all `ech_auth` fields (except the signature itself) ensures integrity of parameters and pins. The `not_after` timestamp provides freshness by bounding the configuration's validity period.
-
 Method-specific `authenticator`:
 
-- RPK (method=1): the DER-encoded SubjectPublicKeyInfo (SPKI) of the signing key. The client MUST compute the SHA-256 hash of the SPKI, verify that it matches one of the hashes in `trusted_keys`, check that the current time is before the `not_after` timestamp, and then verify the signature with this key. The `not_after` field is REQUIRED and MUST be a timestamp strictly greater than the client's current time at verification.
-- PKIX (method=2): a CertificateEntry vector (leaf + optional intermediates) as in TLS 1.3 Certificate; the leaf MUST include the critical `id-pe-echConfigSigning` extension and be valid for the ECHConfig `public_name`. The client validates the chain, confirms the SAN includes the ECH `public_name`, confirms the critical `id-pe-echConfigSigning` extension is present in the leaf, and verifies the signature with the leaf key. The `not_after` field MUST be set to 0 (absent).
+- RPK (method=0): the DER-encoded SubjectPublicKeyInfo (SPKI) of the signing key. The client MUST compute the SHA-256 hash of the SPKI, verify that it matches one of the hashes in `trusted_keys`, check that the current time is before the `not_after` timestamp, and then verify the signature with this key. The `not_after` field is REQUIRED and MUST be a timestamp strictly greater than the client's current time at verification.
+- PKIX (method=1): a CertificateEntry vector (leaf + optional intermediates) as in TLS 1.3 Certificate; the leaf MUST include the critical `id-pe-echConfigSigning` extension and be valid for the ECHConfig `public_name`. The client validates the chain, confirms the SAN includes the ECH `public_name`, confirms the critical `id-pe-echConfigSigning` extension is present in the leaf, and verifies the signature with the leaf key. The `not_after` field MUST be a timestamp strictly greater than the client's current time at verification.
 
 Notes:
 
 - `trusted_keys` is only used by RPK; clients MUST ignore it for PKIX.
-- If `method` is `rpk(1)`, `trusted_keys` MUST contain at least one SPKI hash; otherwise it MUST be zero-length.
+- If `method` is `rpk(0)`, `trusted_keys` MUST contain at least one SPKI hash; otherwise it MUST be zero-length.
 - A server publishing multiple ECHConfigs MAY use different methods for each to maximize client compatibility.
 
 Context-specific requirements:
 
-- When carried in TLS (HelloRetryRequest or EncryptedExtensions), an `ech_auth` extension in each delivered ECHConfig MUST include a signed authenticator in `signature`, and the client MUST verify the authenticator before installing the ECHConfig.
-- When carried in DNS, an `ech_auth` extension MAY omit the `signature` field (unsigned), in which case it conveys only policy (`method`, `trusted_keys`). Clients MAY use such information to attempt ECH and to bootstrap trust, but MUST NOT treat it as an authenticated update. If `signature` is present in DNS, clients SHOULD verify it per the indicated method and MAY treat the ECHConfig as authenticated upon successful verification.
+- When carried in TLS (EncryptedExtensions), an `ech_auth` extension in each delivered ECHConfig MUST include a signed authenticator in `signature`, and the client MUST verify the authenticator before installing the ECHConfig.
+- When carried in DNS, an `ech_authinfo` extension conveys only policy (`method`, `trusted_keys`).
 
-The SPKI hash uses SHA-256 (value 4 in the IANA TLS HashAlgorithm registry). The rationale for using a hash rather than the full SPKI is to keep the extension compact in DNS and on the wire, and to avoid exposing full public keys in the clear. SHA-256 is universally supported and provides sufficient security. The drawback is that hash collisions or second-preimage attacks could undermine the pin – this is considered cryptographically infeasible for SHA-256 at the time of writing.
+The SPKI hash uses SHA-256 (value 4 in the IANA TLS HashAlgorithm registry). Allowing multiple hashes enables seamless key roll overs.
 
 Note: While TLS 1.3 moved to SignatureScheme and doesn't directly use the HashAlgorithm enum, we reference the IANA registry value for clarity. Future versions of this specification could add a hash algorithm field using the TLS HashAlgorithm registry if algorithm agility becomes necessary.
 
-Client behavior: When a client obtains an ECHConfig that contains an `ech_auth` extension, it SHOULD store this information along with the configuration. If the client subsequently uses this ECHConfig to initiate a connection, it relies on delivery of signed ECHConfigs in HRR/EE for in-band updates.
+Client behavior: When a client obtains an ECHConfig that contains an `ech_authinfo` extension, it SHOULD store this information along with the configuration.
 
-If an ECHConfig does not include `ech_auth`, the in-band update mechanism defined here is not used for that configuration.
+Server behavior: A server that wishes to allow authenticated updates MUST include `ech_authinfo` in the ECHConfig it publishes via DNS or other means. The server MUST set the `method` field to the authentication method it will use for this configuration. The server MUST ensure that it actually has the capability to perform the indicated method:
 
-Server behavior: A server that wishes to allow in-band updates MUST include `ech_auth` in the ECHConfig it publishes via DNS or other means. The server MUST set the `method` field to the authentication method it will use for this configuration. The server MUST ensure that it actually has the capability to perform the indicated method:
-
-- If `method` is `rpk(1)`, the server needs a signing key whose SPKI hash is in `trusted_keys`. (It may have multiple keys for rotation; all keys that might sign an update before the next ECHConfig change should be listed. Pins can be added or removed by generating a new ECHConfig with an updated list and distributing it out-of-band or via an update.)
-- If `method` is `pkix(2)`, the server must have a valid certificate (and chain) for the public name with the critical `id-pe-echConfigSigning` extension (Section [IANA Considerations](#iana) defines the extension) available at runtime to use for signing. The certificate's public key algorithm dictates what signature algorithms are possible.
+- If `method` is `rpk(0)`, the server needs a signing key whose SPKI hash is in `trusted_keys`. (It may have multiple keys for rotation; all keys that might sign an update before the next ECHConfig change should be listed.
+- If `method` is `pkix(1)`, the server must have a valid certificate (and chain) for the public name with the critical `id-pe-echConfigSigning` extension (Section [IANA Considerations](#iana) defines the extension) available at runtime to use for signing. The certificate's public key algorithm dictates what signature algorithms are possible.
 
 ## TLS Extensions for ECH Config Update
 
-### EncryptedExtensions / HelloRetryRequest Delivery
+### EncryptedExtensions Delivery
 
-This specification reuses the ECH retry_configs delivery mechanism: the server sends an ECHConfigList where each ECHConfig contains the `ech_auth` extension with a signed authenticator. The server MAY include multiple ECHConfigs with different authentication methods (e.g., one with PKIX and one with RPK) to maximize client compatibility. There is no separate TLS extension for negotiation.
+This specification reuses the ECH retry_configs delivery mechanism: the server sends an ECHConfigList where each ECHConfig contains the `ech_auth` extension with a signed authenticator. The server MAY include multiple ECHConfigs with different authentication methods (e.g., one with PKIX and one with RPK).
 
 ### Server Behavior
 
 When a server receives a ClientHello with the `encrypted_client_hello` extension, it processes ECH per {{!I-D.ietf-tls-esni}}. If the server has an updated ECHConfigList to distribute:
 
-1. ECH Accepted: If the server successfully decrypts the ClientHelloInner, it completes the handshake using the inner ClientHello. The server MAY include authenticated ECHConfigs in EncryptedExtensions if an update is available.
+1. ECH Accepted: If the server successfully decrypts the ClientHelloInner, it completes the handshake using the inner ClientHello.
 
-2. ECH Rejected: If the server cannot decrypt the ClientHelloInner, it SHOULD proceed with the outer handshake and include authenticated ECHConfigs in EncryptedExtensions. This allows the client to immediately retry with the correct configuration.
+2. ECH Rejected: If the server cannot decrypt the ClientHelloInner, it SHOULD proceed with the outer handshake and include signed ECHConfigs in EncryptedExtensions. This allows the client to immediately retry with the correct configuration.
 
-The server prepares authenticated updates by:
-
-- Using the authentication method specified in the ECHConfig's `ech_auth.method`
-- Creating the appropriate authenticator (RPK signature or PKIX certificate chain)
-- Including the authenticator in the ECHConfig's `ech_auth.signature` field
-- Sending the ECHConfigList via the existing `retry_configs` mechanism
+The server may indicate that the client should attempt to retry without ECH by including an ECHAuth extension over an empty config.
 
 ### Client Behavior
 
-When a client retrieves an ECHConfig (e.g., from DNS), it examines the `ech_auth` extension and records:
+When a client retrieves an ECHConfig (e.g., from DNS), it examines the `ech_authinfo` extension and records:
 
 - The authentication `method` (RPK or PKIX)
 - Any `trusted_keys` for RPK validation
-- Any pre-distributed signature for immediate validation
 
-During the TLS handshake, upon receiving an ECHConfigList in HRR or EE:
+During the TLS handshake, upon receiving an ECHConfigList in EE:
 
 1. Validation: The client validates the authenticator according to its method:
    - RPK: Computes the SHA-256 hash of the provided SPKI, verifies it matches one in `trusted_keys`, then verifies the signature
@@ -296,10 +272,10 @@ During the TLS handshake, upon receiving an ECHConfigList in HRR or EE:
 3. Installation and Retry (see Appendix A for state diagram):
    - If validation succeeds and this was an ECH rejection (outer handshake):
      * The client treats the retry_configs as authentic per {{I-D.ietf-tls-esni, Section 6.1.6}}
-     * The client MUST terminate the connection and retry with the new ECHConfig
+     * The client MUST terminate the connection and retry with the new ECHConfig or without ECH if indicated by the server.
      * The retry does not consider the server's TLS certificate for the public name
    - If validation succeeds and this was an ECH acceptance:
-     * The client caches the new ECHConfig for future connections
+     * No changes to the ECH specification
    - If validation fails:
      * The client MUST treat this as if the server's TLS certificate could not be validated
      * The client MUST NOT use the retry_configs
@@ -309,126 +285,76 @@ Note: Regardless of validation outcome in an ECH rejection, the client will term
 
 ### Backward Compatibility
 
-Clients that do not implement this specification continue to process `retry_configs` as defined in {{!I-D.ietf-tls-esni}}, ignoring the authentication extensions. Servers that do not implement this specification send unauthenticated `retry_configs` as usual.
-
+Clients that do not implement this specification continue to process `retry_configs` as defined in {{!I-D.ietf-tls-esni}}, ignoring the authentication extensions. Servers that do not implement this specification send `retry_configs` as usual.
 
 # Example Exchange
 
 ## Initial Setup
 
-Consider `api.example.com` as a service protected by ECH with public name `ech.example.net`. The operator publishes an ECHConfig via DNS HTTPS RR with the `ech_auth` extension containing:
+Consider `api.example.com` as a service protected by ECH with public name `ech.example.net`. The operator publishes an ECHConfig via DNS HTTPS RR with the `ech_authinfo` extension containing:
 
 - Method: RPK (value 1)
 - Trusted keys: SHA-256 hash of an Ed25519 signing key's SPKI
-- Optional: A signed authenticator for immediate validation
 
-## Successful ECH with Update
+## Successful ECH
 
-1. Client connects: Sends ClientHello with ECH using cached config
-   - Outer SNI: `ech.example.net`
-   - Inner SNI: `api.example.com`
-
-2. Server accepts ECH: Decrypts inner ClientHello successfully
-   - Prepares updated ECHConfig with new keys
-   - Selects PKIX method for signing
-   - Signs the update with certificate containing the critical `id-pe-echConfigSigning` extension
-
-3. Server response:
-   - ServerHello (ECH accepted)
-   - EncryptedExtensions containing authenticated ECHConfig
-   - Certificate for `api.example.com` (inner origin)
-   - CertificateVerify, Finished
-
-4. Client validation:
-   - Verifies ECH acceptance
-   - Validates PKIX certificate chain and critical extension
-   - Verifies signature over ECHConfig
-   - Caches new config for future connections
+This flow works identically to existing ECH
 
 ## ECH Rejection with Recovery
 
 1. Client connects: Uses outdated ECHConfig
 2. Server rejects ECH: Cannot decrypt inner ClientHello
 3. Server continues outer handshake:
-   - Sends authenticated ECHConfig in EncryptedExtensions
-   - Uses certificate for `ech.example.net`
+   - Sends signed ECHConfig in EncryptedExtensions
+   - Uses certificate for `foo.example.net`
 4. Client recovery:
-   - Validates and caches new ECHConfig
-   - Closes connection (not authenticated for inner origin)
+   - Validates new ECHConfig
+   - Closes connection
    - Immediately retries with new ECHConfig
 
 # Security Considerations {#security}
 
-This section analyzes security properties by threat model.
-
 ## Passive Attackers
 
-This mechanism preserves ECH's protection against passive observation. ECHConfig updates are delivered within encrypted TLS messages (HelloRetryRequest or EncryptedExtensions), preventing passive observers from learning about configuration changes. The mechanism ensures that even during retry scenarios, the client's intended server name is never exposed in cleartext.
+This mechanism preserves ECH's protection against passive observation. ECHConfig updates are delivered within the EncryptedExtensions TLS message, preventing passive observers from learning about configuration changes. The mechanism ensures that even during retry scenarios, the client's intended server name is never exposed in cleartext.
 
 ## Active Network Attackers
 
-### Initial Trust Bootstrap
+The security of this mechanism fundamentally depends on the authenticity of the initial ECHConfig. If an attacker can inject a malicious initial configuration, the client's privacy is compromised, but their connections remain properly authenticated.
 
-The security of this mechanism fundamentally depends on the authenticity of the initial ECHConfig. If an attacker can inject a malicious initial configuration, they may be able to pin their own keys in the `trusted_keys` field, enabling persistent interception.
+Initial retrieval of ECHConfigList via DNS is unchanged by this mechanism. This specification does not attempt to authenticate the initial DNS fetch. ECHConfigs obtained via HTTPS from a well-known URI benefit from Web PKI authentication. Pre-configured ECHConfigs in applications derive their trust from the application's distribution channel.
 
-When ECHConfigs are obtained via DNS, an on-path attacker could provide a fake ECHConfig with the attacker's key in `trusted_keys`. While the attacker cannot decrypt ECH-protected connections, they could cause ECH to fail and then present their own certificate during fallback, potentially tricking the client into accepting and caching a compromised configuration. Clients SHOULD prefer authenticated bootstrap mechanisms when available.
+### Retry Configuration Integrity
 
-Initial retrieval of ECHConfigList via DNS is unchanged by this mechanism. This specification authenticates updates in-band via RPK or PKIX; it does not attempt to authenticate the initial DNS fetch. ECHConfigs obtained via HTTPS from a well-known URI benefit from Web PKI authentication. Pre-configured ECHConfigs in applications derive their trust from the application's distribution channel.
+ECHConfigs delivered in EncryptedExtensions are usually protected by TLS 1.3's handshake encryption and integrity mechanisms. The Finished message ensures that any modification by an attacker would be detected. The authenticity of the Finished message is assured by validating the server's certificate chain, which the client checks is valid for the ECH Public Name.
 
-### Handshake Integrity
+However, signed ECHConfigs don't benefit from this authentication because the client does not validate the server's certificate chain. Instead, the client verifies the ECHConfigs against the authenticator provided in the initial ECHConfig. This provides the same level of authenticity as checking the ECH Public Name would.
 
-Signed ECHConfigs delivered via HelloRetryRequest or EncryptedExtensions are protected by TLS 1.3's handshake encryption and integrity mechanisms. The Finished message ensures that any modification by an attacker would be detected.
-
-A man-in-the-middle attacker without the server's handshake keys cannot modify the EncryptedExtensions message containing the ECHConfig update. The TLS 1.3 handshake itself provides replay protection through its use of fresh random values and the Finished message authentication.
-
-## Compromised Keys
-
-### Signature Verification
-
-Clients MUST correctly implement signature verification for each authentication method. For RPK, servers and clients SHOULD use cryptographically strong signature schemes from the TLS 1.3 SignatureScheme registry, such as Ed25519, ECDSA, or RSA-PSS. Weak schemes like RSA PKCS#1 v1.5 SHOULD NOT be used.
-
-The inclusion of `not_after` timestamps (for RPK) or certificate validity periods (for PKIX) ensures configuration freshness. These temporal bounds prevent clients from accepting stale configurations that might use compromised keys or outdated parameters. Clients MUST verify these temporal constraints and reject expired configurations. Note that these mechanisms depend on reasonably synchronized clocks (within 5 minutes of actual time is RECOMMENDED).
-
-Note that signed ECHConfigs themselves are replayable - an attacker could capture and resend a valid signed configuration. However, this is not a security concern as the configuration is public data intended for distribution. The freshness guarantees ensure that old configurations eventually expire, limiting the window during which outdated keys remain acceptable.
+he inclusion of `not_after` timestamps (for RPK) or certificate validity periods (for PKIX) ensures configuration freshness. These temporal bounds prevent clients from accepting stale configurations that might use compromised keys or otherwise parameters. ECH providers should use a window of 24 hours.
 
 ### Key Management
 
-Servers MUST protect their ECH update signing keys. If an RPK signing key is compromised, the server SHOULD remove its hash from `trusted_keys` in subsequent updates, signing the transition with a different trusted key. Servers SHOULD consider including multiple keys in `trusted_keys` to facilitate key rotation and recovery from compromise.
+Servers MUST protect their ECH update signing keys. If an RPK signing key is compromised, the server SHOULD remove its hash from `trusted_keys`. Servers SHOULD including multiple keys in `trusted_keys` to facilitate key rotation and recovery from compromise.
 
 For PKIX-based updates, normal certificate lifecycle management applies. Servers SHOULD obtain new certificates before existing ones expire.
-
-For PKIX authentication, this specification leverages existing CA infrastructure including revocation mechanisms. A compromised ECH signing certificate could be used to sign malicious updates, but this risk is mitigated by the certificate's constraints (critical extension and name binding) and standard revocation mechanisms (OCSP/CRL). Clients SHOULD apply the same revocation checks to ECH signing certificates as they do for TLS server certificates.
 
 ## Implementation Vulnerabilities
 
 ### Failure Handling
 
-When ECHConfig update verification fails, clients MUST NOT compromise the security or privacy guarantees of ECH. If ECH was accepted but the update verification failed, the connection proceeds normally without caching the new configuration. This represents a safe failure mode where connectivity is maintained but key rotation is delayed.
-
-If ECH was rejected and the update verification also fails, the client lacks a valid configuration for retry. In this case, the client SHOULD NOT proceed with the connection using the outer SNI for application data, as this would violate ECH's privacy goals. The client MAY attempt to obtain a valid configuration through other means (such as DNS) or treat the connection as failed.
-
-Servers MAY include multiple ECHConfigs with different authentication methods to maximize the probability of successful verification. Clients SHOULD process these in order and use the first configuration that successfully verifies.
-
-In distributed deployments, only servers with access to the appropriate signing keys can generate valid ECHConfig updates. This prevents unauthorized intermediaries (such as CDN nodes) from injecting malicious configurations. If a server sends an update that cannot be verified, the client simply ignores it and continues with its existing configuration. While this could potentially lead to the use of outdated configurations, it prevents compromise of the ECH mechanism itself.
+ECH connection attempts with signed updates are handled identically to existing ECH connection attempts. The only difference is in how the server authenticates retry configurations, not how it responds to the success or failure of that authentication.
 
 Algorithm agility is provided through the TLS SignatureScheme registry for RPK and standard PKIX certificate algorithms. Implementations SHOULD support commonly deployed algorithms and MUST be able to handle algorithm transitions.
 
 ### Denial of Service Considerations
 
-Signature verification introduces computational costs. However, these operations occur only during ECH configuration updates, not on every connection. The additional data in EncryptedExtensions (certificates) may increase message sizes, potentially causing fragmentation in some scenarios. Implementations SHOULD be aware of message size limits, particularly in QUIC deployments.
+The ECH Specification allows ECH Operators to decide which ECH extensions to attempt to decrypt based on the public ECHConfig ID advertised in the Client Hello and the public SNI name. This extension reduces the value of that signal, meaning that ECH operators will need to be willing to trial decrypt incoming ECH extensions. This is not a substantial burden, should be accounted for when provisioning these signed configs.
 
 Attackers cannot force servers to send signed ECHConfigs without establishing TLS connections. Standard TLS denial-of-service mitigations (rate limiting, stateless cookies) apply equally to this mechanism.
 
-
 # Privacy Considerations
 
-This mechanism preserves and potentially enhances ECH's privacy properties. By enabling the use of diverse public names through RPK authentication, servers can increase the anonymity set beyond what is possible with certificate-based authentication alone.
-
-The ECHConfig updates themselves are delivered within encrypted TLS messages (HelloRetryRequest or EncryptedExtensions), preventing passive observers from learning about configuration changes. The mechanism ensures that even during retry scenarios, the client's intended server name is never exposed in cleartext.
-
-A potential privacy consideration is that failed ECH attempts followed by successful retries create a distinctive connection pattern. However, this pattern only reveals that ECH was used with a particular public name, not the intended destination behind that name.
-
-This specification introduces no new tracking mechanisms or identifiers beyond those already present in TLS and DNS.
+This specification introduces no new risks those already present in TLS and DNS when used with ECH.
 
 # IANA Considerations {#iana}
 
@@ -436,9 +362,14 @@ This specification introduces no new tracking mechanisms or identifiers beyond t
 
 IANA is requested to add the following entry to the "ECH Configuration Extension Type Values" registry:
 
-- Extension Name: `ech_auth`
+- Extension Name: `ech_authinfo`
 - Value: TBD1
-- Purpose: Conveys supported authentication methods, trusted keys, and optional signed authenticators
+- Purpose: Conveys supported authentication methods and trusted keys
+- Reference: This document
+
+- Extension Name: `ech_auth`
+- Value: TBD2
+- Purpose: Conveys authenticator and signatures
 - Reference: This document
 
 ## X.509 Certificate Extension OID
@@ -457,10 +388,9 @@ IANA is requested to establish a new registry called "ECH Authentication Methods
 
 | Value | Method     | Description                                  | Reference      |
 |-------|------------|----------------------------------------------|----------------|
-| 0     | Reserved   | Not used                                     | This document  |
-| 1     | RPK        | Raw Public Key                               | This document  |
-| 2     | PKIX       | X.509 with critical id-pe-echConfigSigning   | This document  |
-| 3-255 | Unassigned | -                                            | -              |
+| 0     | RPK        | Raw Public Key                               | This document  |
+| 1     | PKIX       | X.509 with critical id-pe-echConfigSigning   | This document  |
+| 2-255 | Unassigned | -                                            | -              |
 
 New values are assigned via IETF Review.
 
@@ -468,27 +398,15 @@ New values are assigned via IETF Review.
 
 ## Method Selection
 
-Operators SHOULD support at least one widely implemented method. PKIX (critical extension) provides easier operational deployment with standard certificate issuance workflows and no client pin state. RPK offers small artifacts and simple verification; any client-side state is bounded to the lifetime of the current ECHConfig and a single authenticated retry per connection attempt.
+Operators SHOULD support at least one widely implemented method. PKIX (critical extension) provides easier operational deployment with standard certificate issuance workflows. RPK offers small artifacts and simple verification but must the list of hashed keys and those used for signing must be carefully kept in sync.
 
 ## Size Considerations
 
-When sending authenticated ECHConfigs in HelloRetryRequest, servers should be mindful of message size to avoid fragmentation or exceeding anti-amplification limits. RPK signatures are typically more compact than PKIX certificate chains.
+When sending signed ECHConfigs in EncryptedExtensions, servers should be mindful of message size to avoid fragmentation or exceeding anti-amplification limits. RPK signatures are typically more compact than PKIX certificate chains.
 
 ## Key Rotation
 
 Publish updates well in advance of key retirement. Include appropriate validity periods for each method. Consider overlapping validity windows to allow graceful client migration.
-
-## Pin Management
-
-For RPK deployments:
-
-- Maintain multiple valid pins to enable recovery from key compromise
-- Remove compromised pins via authenticated updates signed by remaining trusted keys
-- Consider using PKIX to re-establish trust if all pinned keys are compromised
-
-## Update Consistency
-
-If sending updates in both HRR and EncryptedExtensions, ensure consistency to avoid client confusion. When possible, send updates in only one location per handshake.
 
 # Acknowledgments
 

--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -21,9 +21,13 @@ author:
   - fullname: Dennis Jackson
     organization: Mozilla
     email: ietf@dennis-jackson.uk
+  - fullname: Alessandro Ghedini
+    organization: Cloudflare
+    email: alessandro@cloudflare.com
 
 normative:
   RFC2119:
+  RFC5280:
   RFC8174:
   RFC8446:
   RFC9180:
@@ -31,8 +35,6 @@ normative:
   I-D.ietf-tls-esni:
   I-D.ietf-tls-svcb-ech:
   I-D.ietf-tls-wkech:
-
-informative:
 
 venue:
   group: TLS
@@ -42,263 +44,504 @@ venue:
 
 --- abstract
 
-Encrypted ClientHello (ECH) requires clients to have the server's ECH configuration before connecting. Currently, when ECH fails, servers can send updated configurations but clients cannot authenticate them unless the server has a valid certificate for the public name, limiting deployment flexibility.
+Encrypted ClientHello (ECH) requires clients to have the
+server's ECH configuration before connecting.  Currently,
+when ECH fails, servers can send updated configurations but
+clients cannot authenticate them unless the server has a
+valid certificate for the public name, limiting deployment
+flexibility.
 
-This document specifies a new mechanism for authenticating ECH configurations. Servers include additional information in their initial ECH configurations, which enables clients to authenticate updated configurations without relying on a valid certificate for the public name.
+This document specifies a new mechanism for authenticating
+ECH configurations.  Servers include additional information
+in their initial ECH configurations, which enables clients
+to authenticate updated configurations without relying on a
+valid certificate for the public name.
 
 --- middle
 
 # Introduction
 
-Deployment of TLS Encrypted ClientHello (ECH) requires that clients obtain the server's current ECH configuration (ECHConfig) before initiating a connection. Current mechanisms distribute ECHConfig data via DNS HTTPS resource records {{!RFC9460}} or HTTPS well-known URIs {{!I-D.ietf-tls-wkech}}, allowing servers to publish their ECHConfigList prior to connection establishment.
+Deployment of TLS Encrypted ClientHello (ECH) requires that
+clients obtain the server's current ECH configuration
+(ECHConfig) before initiating a connection.  Current
+mechanisms distribute ECHConfig data via DNS HTTPS resource
+records {{!RFC9460}} or HTTPS well-known URIs
+{{!I-D.ietf-tls-wkech}}, allowing servers to publish their
+ECHConfigList prior to connection establishment.
 
-ECH includes a retry mechanism where servers can send an updated ECHConfigList during the handshake, the base ECH specification instructs clients to authenticate this information using a certificate valid for the public name {{!I-D.ietf-tls-esni}}.
+ECH includes a retry mechanism where servers can send an
+updated ECHConfigList during the handshake.  The base ECH
+specification instructs clients to authenticate this
+information using a certificate valid for the public name
+{{!I-D.ietf-tls-esni}}.
 
-This forces a tradeoff between security and privacy for server operators. Using the same public name for as many websites as possible improves client privacy, but makes obtaining or compromising a valid certificate for that cover name a high value target for attackers. It also restricts the usable public names in an ECH deployment to those for which operators can obtain valid certificates.
+This forces a tradeoff between security and privacy for
+server operators.  Using the same public name for as many
+websites as possible improves client privacy, but makes
+obtaining or compromising a valid certificate for that
+cover name a high value target for attackers.  It also
+restricts the usable public names in an ECH deployment to
+those for which operators can obtain valid certificates.
 
-This document introduces an alternative authentication mechanism for ECHConfig data which doesn't rely on the public name used in the initial ECHConfig. This allows server operators to partition the retry configuration between different domains, as well as enabling a greater flexibility in the public name used.
+This document introduces an alternative authentication
+mechanism for ECHConfig data which does not require the
+server to hold a valid TLS certificate for the public
+name.  This allows server operators to partition the retry
+configuration between different domains, as well as
+enabling greater flexibility in the public name used.
 
 The mechanism supports two authentication methods:
 
-1. Raw Public Key (RPK) - Uses SPKI hashes to identify public keys for retry authentication.
-2. PKIX - Uses certificate-based signing with a critical X.509 extension.
+1. Raw Public Key (RPK) - Uses SPKI hashes to identify
+   public keys for retry authentication.
+2. PKIX - Uses certificate-based signing with a critical
+   X.509 extension.
 
-Each ECH Retry Configuration carries at most one signature using the specified method, replacing the need to authenticate the ECH Retry configuration through the TLS handshake and ECH Public Name.
+Each ECH Retry Configuration carries at most one signature
+using the specified method, replacing the need to
+authenticate the ECH Retry configuration through the TLS
+handshake and ECH Public Name.
 
 # Conventions and Definitions
 
-The key words "MUST", "MUST NOT", "SHOULD", "SHOULD NOT", and "MAY" in this document are to be interpreted as described in BCP 14 {{!RFC2119}} {{!RFC8174}} when, and only when, they appear in all capitals.
+{::boilerplate bcp14}
 
-This document assumes familiarity with TLS 1.3 {{!RFC8446}} and the ECH specification {{!I-D.ietf-tls-esni}}, referred to here as simply "ECH".
-
-The following acronyms are used throughout this document:
-
-- RPK: Raw Public Key - A public key used directly without a certificate wrapper
-- PKIX: Public Key Infrastructure using X.509 - The standard certificate-based PKI used on the web
-- SPKI: SubjectPublicKeyInfo - The ASN.1 structure containing a public key and its algorithm identifier
-- HPKE: Hybrid Public Key Encryption - The encryption scheme used by ECH as defined in {{!RFC9180}}
-- DER: Distinguished Encoding Rules - A binary encoding format for ASN.1 structures
-- CA: Certificate Authority - An entity that issues digital certificates
+This document assumes familiarity with TLS 1.3
+{{!RFC8446}} and the ECH specification
+{{!I-D.ietf-tls-esni}}, referred to here as simply "ECH".
 
 ## Terminology
 
 ECHConfig:
-: An individual ECH configuration structure as defined in {{!I-D.ietf-tls-esni}}, which includes fields such as `public_name`, `public_key` (HPKE key), and extensions.
+: An individual ECH configuration structure as defined in
+  {{!I-D.ietf-tls-esni}}, which includes fields such as
+  `public_name`, `public_key` (HPKE key), and extensions.
 
 ECHConfigList:
-: A sequence of one or more ECHConfig structures as defined in ECH (a byte string that starts with a 16-bit length and may contain multiple concatenated ECHConfig values).
+: A sequence of one or more ECHConfig structures as
+  defined in ECH (a byte string that starts with a 16-bit
+  length and may contain multiple concatenated ECHConfig
+  values).
 
 ECHConfigTBS (To-Be-Signed):
-: The serialized ECHConfig structure with the `ech_auth` extension, but with the `signature` field within `ech_auth.signature` set to zero-length. This includes all ECHConfig fields and the `ech_auth` extension's `method` and `trusted_keys` fields.
+: The serialized ECHConfig structure including the
+  `ech_auth` extension, but with the `signature` field
+  within `ech_auth` set to zero-length.  This includes all
+  ECHConfig fields and the `ech_auth` extension's `method`,
+  `not_after`, `authenticator`, and `algorithm` fields.
 
 signed ECHConfig:
-: An ECHConfig that contains an `ech_auth` extension with a valid signature in the `signature` field, allowing clients to verify its authenticity.
+: An ECHConfig that contains an `ech_auth` extension with
+  a valid signature in the `signature` field, allowing
+  clients to verify its authenticity.
 
 public name:
-: The value of the `public_name` field in the ECHConfig, i.e., the authoritative DNS name for updates and validation associated with that configuration. This name is not required to be the ClientHelloOuter SNI, though deployments sometimes choose to align them.
+: The value of the `public_name` field in the ECHConfig,
+  i.e., the authoritative DNS name for updates and
+  validation associated with that configuration.  This
+  name is not required to be the ClientHelloOuter SNI,
+  though deployments sometimes choose to align them.
 
 retry_configs:
-: The ECHConfigList sent by a server in EncryptedExtensions when ECH is rejected, as defined in {{!I-D.ietf-tls-esni}}.
+: The ECHConfigList sent by a server in
+  EncryptedExtensions when ECH is rejected, as defined in
+  {{!I-D.ietf-tls-esni}}.
 
 outer SNI:
-: The Server Name Indication value sent in the outer (unencrypted) ClientHello when ECH is used. This is typically the ECHConfig's `public_name` or another name that preserves client privacy.
+: The Server Name Indication value sent in the outer
+  (unencrypted) ClientHello when ECH is used.  This is
+  typically the ECHConfig's `public_name` or another name
+  that preserves client privacy.
 
-The reader should recall that in TLS 1.3, the server's EncryptedExtensions message is encrypted and integrity-protected with handshake keys {{!I-D.ietf-tls-esni}}. New extensions defined as part of EncryptedExtensions are not visible to network attackers and cannot be modified by an attacker without detection. Additionally, "certificate verification" refers to the standard X.509 validation process (chain building, signature and expiration checking, name matching, etc.) unless otherwise specified.
+The reader should recall that in TLS 1.3, the server's
+EncryptedExtensions message is encrypted and
+integrity-protected with handshake keys
+{{!I-D.ietf-tls-esni}}.  New extensions defined as part
+of EncryptedExtensions are not visible to network attackers
+and cannot be modified by an attacker without detection.
+Additionally, "certificate verification" refers to the
+standard X.509 validation process (chain building,
+signature and expiration checking, name matching, etc.)
+unless otherwise specified.
 
 # Mechanism Overview
 
-This specification defines two methods for authenticating ECH configuration updates:
+This specification defines two methods for authenticating
+ECH configuration updates:
 
-Raw Public Keys (RPK) has little wire overhead and no external dependencies. The site offering ECH places one or more public key hashes in their ECH Configs, then can use those keys to sign ECH Retry Configs. However, key rotation must be managed by the site operator, through updates to the list of trusted public key hashes.
+Raw Public Keys (RPK) has little wire overhead and no
+external dependencies.  The site offering ECH places one
+or more public key hashes in their ECH Configs, then can
+use those keys to sign ECH Retry Configs.  However, key
+rotation must be managed by the site operator, through
+updates to the list of trusted public key hashes.
 
-PKIX has a larger wire overhead and requires coordination with an issuing CA - who must provide certificates with an appropriate extension. However, it doesn't require any manual key rotation. The public name used to authenticate the certificate is a fixed string, which is never visible on the wire, and the operator can rotate certificate chains without any needing to change their advertised ECHConfigs.
+PKIX has a larger wire overhead and requires coordination
+with an issuing CA who must provide certificates with an
+appropriate extension.  However, it does not require any
+manual key rotation.  The public name used to authenticate
+the certificate is a fixed string, which is never visible
+on the wire, and the operator can rotate certificate chains
+without needing to change their advertised ECHConfigs.
 
 ## Raw Public Key (RPK)
 
-The ECHConfigList update is authenticated by a Raw Public Key (RPK). The ECHConfig's `ech_authinfo` extension carries a set of `trusted_keys`, each value being `SHA-256(SPKI)` of an RPK that is authorized to sign an update.
+The ECHConfigList update is authenticated by a Raw Public
+Key (RPK).  The ECHConfig's `ech_authinfo` extension
+carries a set of `trusted_keys`, each value being
+`SHA-256(SPKI)` of an RPK that is authorized to sign an
+update.
 
-A client receiving a signed ECH retry configuration (e.g., in Encrypted Extensions) MUST:
+A client receiving a signed ECH retry configuration (e.g.,
+in EncryptedExtensions) MUST:
 
-1. Extract the authenticator key's SubjectPublicKeyInfo (SPKI) and compute `sha256(spki)`. Verify membership in `trusted_keys`.
-2. Verify that `not_after` is strictly greater than the client's current time.
-3. Verify the signature over the ECH Configuration and the `not_after` using the authenticator's public key.
+1. Extract the authenticator key's SubjectPublicKeyInfo
+   (SPKI) and compute `sha256(spki)`.  Verify membership
+   in `trusted_keys`.
+2. Verify that `not_after` is strictly greater than the
+   client's current time.
+3. Verify the signature over the ECH Configuration and the
+   `not_after` using the authenticator's public key.
 
-The client may then use the signed ECH retry configuration to make a new connection attempt, in line with the existing rules for ECH retrys laid out in the ECH specification. Alternatively, if the server wants the client to disable ECH then it can produce a signature over an empty ECHConfig to indicate that.
+The client may then use the signed ECH retry configuration
+to make a new connection attempt, in line with the existing
+rules for ECH retries laid out in the ECH specification.
+Alternatively, the server can indicate that ECH should not
+be used by producing a signature over a zero-length
+ECHConfigList.  Clients receiving a verified zero-length
+list MUST NOT attempt ECH on the subsequent retry and
+SHOULD clear any cached ECHConfig for this public name.
 
 ## PKIX (Certificate-Based)
 
-The update is signed with the private key corresponding to an X.509 certificate that chains to a client trusted root and is valid for the ECHConfig `public_name` (i.e., appears in the certificate's SAN).
+The update is signed with the private key corresponding to
+an X.509 certificate that chains to a client trusted root
+and is valid for the ECHConfig `public_name` (i.e.,
+appears in the certificate's SAN).
 
-The leaf certificate MUST include a new, critical X.509 v3 extension `id-pe-echConfigSigning` (OID: TBD) whose presence indicates authorization to sign ECH configuration updates for the DNS names in the certificate's SAN. Clients:
+The leaf certificate MUST include a new, critical X.509
+v3 extension `id-pe-echConfigSigning` (OID: TBD) whose
+presence indicates authorization to sign ECH configuration
+updates for the DNS names in the certificate's SAN.
+Clients MUST perform standard X.509 certificate validation
+per {{!RFC5280, Section 6}} and additionally:
 
-- MUST validate the certificate chain according to local policy;
 - MUST confirm the SAN covers the ECHConfig `public_name`;
-- MUST confirm the critical `id-pe-echConfigSigning` extension is present in the leaf; and
-- MUST verify the ECH signature with the leaf key.
-- MUST verify that the `not_after` field in `ech_auth.signature` is strictly greater than the client's current time.
+- MUST confirm the critical `id-pe-echConfigSigning`
+  extension is present in the leaf;
+- MUST verify the ECH signature with the leaf key; and
+- MUST verify that the `not_after` field in `ech_auth` is
+  strictly greater than the client's current time.
 
-When this critical extension is present, clients MUST NOT accept the certificate for TLS server authentication. The use of a the critical bit ensures that even clients who are unaware of the extension, will not accept it for TLS server authentication.
+When this critical extension is present, clients MUST NOT
+accept the certificate for TLS server authentication.  The
+use of the critical bit ensures that even clients who are
+unaware of the extension will not accept it for TLS server
+authentication.
 
 # Benefits of Signed ECH Configurations
 
-By treating ECH configurations as signed objects, this mechanism decouples trust in ECH keys from the TLS handshake's certificate validation of the origin. This enables several important capabilities:
+By treating ECH configurations as signed objects, this
+mechanism decouples trust in ECH keys from the TLS
+handshake's certificate validation of the origin.  This
+enables several important capabilities:
 
 ## Distinct Public Names Without CA Certificates
 
-A server can use many different public hostnames (even per-client, per-connection unique ones) for other operational reasons {{!I-D.ietf-tls-esni}}, without having to obtain certificates for each. This was not possible under the original ECH design, which required a valid certificate for any public name used {{!I-D.ietf-tls-esni}}.
+A server can use many different public hostnames (even
+per-client, per-connection unique ones) for other
+operational reasons {{!I-D.ietf-tls-esni}}, without having
+to obtain certificates for each.  This was not possible
+under the original ECH design, which required a valid
+certificate for any public name used
+{{!I-D.ietf-tls-esni}}.
 
-## Isolating privacy-critical key material
+## Isolating Privacy-Critical Key Material
 
-In a large CDN deployment, the ECH specification requires many endpoints to have access to key material which can authenticate a TLS connection for the ECH Cover Name. This raises privacy and security risks - where compromise of the private key material in turn compromises the privacy of ECH users and the security of normal TLS connections to the cover name. Both the mechanisms introduced in this document avoid this problematic sharing of private key material, reducing the risk for ECH operators.
+In a large CDN deployment, the ECH specification requires
+many endpoints to have access to key material which can
+authenticate a TLS connection for the ECH Cover Name.
+This raises privacy and security risks where compromise of
+the private key material in turn compromises the privacy
+of ECH users and the security of normal TLS connections to
+the cover name.  Both mechanisms introduced in this
+document avoid this problematic sharing of private key
+material, reducing the risk for ECH operators.
 
 # Protocol Elements {#wire-formats}
 
-This section specifies the new extensions and data structures in detail. All multi-byte values are in network byte order (big-endian). The syntax uses the TLS presentation language from {{!RFC8446}}.
+This section specifies the new extensions and data
+structures in detail.  All multi-byte values are in network
+byte order (big-endian).  The syntax uses the TLS
+presentation language from {{!RFC8446}}.
 
-## ECH authentication extensions (`ech_auth`)
+## ECH Authentication Extensions {#extensions}
 
-The information for authenticating retry configs is carried as an ECHConfig extension (`ech_authinfo`) inside the ECHConfig structure and conveys authentication policy. ECH Retry Configs include an `ech_auth` extension which includes signed authenticator that allows clients to verify the provided config independently of the TLS handshake.
+The information for authenticating retry configs is carried
+as an ECHConfig extension (`ech_authinfo`) inside the
+ECHConfig structure and conveys authentication policy.  ECH
+Retry Configs include an `ech_auth` extension which
+includes a signed authenticator that allows clients to
+verify the provided config independently of the TLS
+handshake.
 
-The `ech_auth` extension MUST be the last extension in the ECHConfig's extension list. This ensures that the signature in the extension covers all other extensions in the ECHConfigTBS. Implementations MUST place this extension last when constructing an ECHConfig, and MUST reject ECHConfigs where `ech_auth` is not the last extension.
+The `ech_auth` extension MUST be the last extension in the
+ECHConfig's extension list.  This simplifies ECHConfigTBS
+construction: the signature field is at a fixed position
+relative to the end of the serialized ECHConfig, so
+implementations can set it to zero-length without parsing
+earlier extensions.  Implementations MUST place this
+extension last when constructing an ECHConfig, and MUST
+reject ECHConfigs where `ech_auth` is not the last
+extension.
 
-The `ech_auth` and`ech_authinfo` extensions have the following structure:
+The `ech_auth` and `ech_authinfo` extensions have the
+following structure:
 
+~~~~
     enum {
         rpk(0),
         pkix(1),
         (255)
     } ECHAuthMethod;
 
-    // We reuse the TLS HashAlgorithm registry values (though TLS 1.3 itself
-    // doesn't use this enum directly, the registry still exists)
-    // For now, implementations MUST use sha256(4). Future specs may allow others.
-    opaque SPKIHash<32..32>;  // SHA-256 hash of DER-encoded SPKI
+    opaque SPKIHash<32..32>;
 
     struct {
-      ECHAuthMethod method;              // Single authentication method
-      SPKIHash trusted_keys<0..2^16-1>;  // RPK-only; SHA-256 hashes per IANA TLS
+      ECHAuthMethod method;
+      SPKIHash trusted_keys<0..2^16-1>;
     } ECHAuthInfo;
 
-  struct {
-    ECHAuth method
-    uint64 not_after;
-    opaque authenticator<1..2^16-1>; //Holds either RPK DER or PKIX certificate
-    SignatureScheme algorithm;
+    struct {
+        ECHAuthMethod method;
+        uint64 not_after;
+        opaque authenticator<1..2^16-1>;
+        SignatureScheme algorithm;
         opaque signature<1..2^16-1>;
-      } signature;
-  } ECHAuth
+    } ECHAuth;
+~~~~
 
 ### Signature Computation
 
 The signature is computed over the concatenation:
 
-    context_label = "TLS-ECH-AUTH-v1"  // ASCII, no NUL
+~~~~
+    context_label = "TLS-ECH-AUTH-v1"
     to_be_signed = context_label || ECHConfigTBS
+~~~~
 
 where:
 
-- `ECHConfigTBS` (To-Be-Signed) is the serialized ECHConfig structure including
-  the `ech_auth` extension, but with the `signature` field within `ech_auth.signature`
-  set to zero-length. This means `ECHConfigTBS` includes:
-  - All ECHConfig base fields (version, length, contents, etc.)
-  - All extensions including `ech_auth` (which MUST be last)
-  - Within `ech_auth`: the `method`, and the authenticator/
-    not_after/algorithm fields from `signature`, but NOT the actual signature
-    bytes
-- The signature is computed over this entire structure.
-- All multi-byte values use network byte order (big-endian)
-- The serialization follows TLS 1.3 presentation language rules from RFC 8446
+- `ECHConfigTBS` (To-Be-Signed) is the serialized
+  ECHConfig structure including the `ech_auth` extension,
+  but with the `signature` field within `ech_auth` set to
+  zero-length.  This includes all ECHConfig fields and
+  the `ech_auth` extension's `method`, `not_after`,
+  `authenticator`, and `algorithm` fields.
+- All multi-byte values use network byte order
+  (big-endian).
+- The serialization follows TLS 1.3 presentation language
+  rules from {{RFC8446}}.
+
+Note: `trusted_keys` is intentionally not covered by the
+signature.  Including it would require existing authorized
+keys to sign transitions when adding or removing keys,
+creating operational risk if all keys are lost.  The
+security model relies on the authenticity of the initial
+ECHConfig distribution for the authorized key set.
+
+For both methods, `not_after` bounds the replay window
+independently of any certificate validity period.  Shorter
+windows reduce the replay window but require more frequent
+signature generation.  Longer windows allow pre-signing but
+increase exposure to replayed configurations.  A window of
+24 hours is RECOMMENDED as a balance between operational
+simplicity and replay resistance.
 
 Method-specific `authenticator`:
 
-- RPK (method=0): the DER-encoded SubjectPublicKeyInfo (SPKI) of the signing key. The client MUST compute the SHA-256 hash of the SPKI, verify that it matches one of the hashes in `trusted_keys`, check that the current time is before the `not_after` timestamp, and then verify the signature with this key. The `not_after` field is REQUIRED and MUST be a timestamp strictly greater than the client's current time at verification.
-- PKIX (method=1): a CertificateEntry vector (leaf + optional intermediates) as in TLS 1.3 Certificate; the leaf MUST include the critical `id-pe-echConfigSigning` extension and be valid for the ECHConfig `public_name`. The client validates the chain, confirms the SAN includes the ECH `public_name`, confirms the critical `id-pe-echConfigSigning` extension is present in the leaf, and verifies the signature with the leaf key. The `not_after` field MUST be a timestamp strictly greater than the client's current time at verification.
+- RPK (method=0): the DER-encoded SubjectPublicKeyInfo
+  (SPKI) of the signing key.  The client MUST compute the
+  SHA-256 hash of the SPKI, verify that it matches one of
+  the hashes in `trusted_keys`, check that the current
+  time is before the `not_after` timestamp, and then
+  verify the signature with this key.  The `not_after`
+  field is REQUIRED and MUST be a timestamp strictly
+  greater than the client's current time at verification.
+- PKIX (method=1): a CertificateEntry vector (leaf +
+  optional intermediates) as in TLS 1.3 Certificate; the
+  leaf MUST include the critical `id-pe-echConfigSigning`
+  extension and be valid for the ECHConfig `public_name`.
+  The client validates the chain, confirms the SAN
+  includes the ECH `public_name`, confirms the critical
+  `id-pe-echConfigSigning` extension is present in the
+  leaf, and verifies the signature with the leaf key.  The
+  `not_after` field MUST be a timestamp strictly greater
+  than the client's current time at verification.
 
 Notes:
 
-- `trusted_keys` is only used by RPK; clients MUST ignore it for PKIX.
-- If `method` is `rpk(0)`, `trusted_keys` MUST contain at least one SPKI hash; otherwise it MUST be zero-length.
-- A server publishing multiple ECHConfigs MAY use different methods for each to maximize client compatibility.
+- `trusted_keys` is only used by RPK; clients MUST ignore
+  it for PKIX.
+- If `method` is `rpk(0)`, `trusted_keys` MUST contain at
+  least one SPKI hash; otherwise it MUST be zero-length.
+- A server publishing multiple ECHConfigs MAY use different
+  methods for each to maximize client compatibility.
 
 Context-specific requirements:
 
-- When carried in TLS (EncryptedExtensions), an `ech_auth` extension in each delivered ECHConfig MUST include a signed authenticator in `signature`, and the client MUST verify the authenticator before installing the ECHConfig.
-- When carried in DNS, an `ech_authinfo` extension conveys only policy (`method`, `trusted_keys`).
+- When carried in TLS (EncryptedExtensions), an `ech_auth`
+  extension in each delivered ECHConfig MUST include a
+  signed authenticator in `signature`, and the client MUST
+  verify the authenticator before installing the ECHConfig.
+- When carried in DNS, an `ech_authinfo` extension conveys
+  only policy (`method`, `trusted_keys`).
 
-The SPKI hash uses SHA-256 (value 4 in the IANA TLS HashAlgorithm registry). Allowing multiple hashes enables seamless key roll overs.
+The SPKI hash uses SHA-256 (value 4 in the IANA TLS
+HashAlgorithm registry).  Allowing multiple hashes enables
+seamless key rollovers.
 
-Note: While TLS 1.3 moved to SignatureScheme and doesn't directly use the HashAlgorithm enum, we reference the IANA registry value for clarity. Future versions of this specification could add a hash algorithm field using the TLS HashAlgorithm registry if algorithm agility becomes necessary.
+Note: While TLS 1.3 moved to SignatureScheme and does not
+directly use the HashAlgorithm enum, we reference the IANA
+registry value for clarity.  Future versions of this
+specification could add a hash algorithm field using the
+TLS HashAlgorithm registry if algorithm agility becomes
+necessary.
 
-Client behavior: When a client obtains an ECHConfig that contains an `ech_authinfo` extension, it SHOULD store this information along with the configuration.
+Client behavior: When a client obtains an ECHConfig that
+contains an `ech_authinfo` extension, it SHOULD store this
+information along with the configuration.
 
-Server behavior: A server that wishes to allow authenticated updates MUST include `ech_authinfo` in the ECHConfig it publishes via DNS or other means. The server MUST set the `method` field to the authentication method it will use for this configuration. The server MUST ensure that it actually has the capability to perform the indicated method:
+Server behavior: A server that wishes to allow
+authenticated updates MUST include `ech_authinfo` in the
+ECHConfig it publishes via DNS or other means.  The server
+MUST set the `method` field to the authentication method it
+will use for this configuration.  The server MUST ensure
+that it actually has the capability to perform the
+indicated method:
 
-- If `method` is `rpk(0)`, the server needs a signing key whose SPKI hash is in `trusted_keys`. (It may have multiple keys for rotation; all keys that might sign an update before the next ECHConfig change should be listed.
-- If `method` is `pkix(1)`, the server must have a valid certificate (and chain) for the public name with the critical `id-pe-echConfigSigning` extension (Section [IANA Considerations](#iana) defines the extension) available at runtime to use for signing. The certificate's public key algorithm dictates what signature algorithms are possible.
+- If `method` is `rpk(0)`, the server needs a signing key
+  whose SPKI hash is in `trusted_keys`.  It may have
+  multiple keys for rotation; all keys that might sign an
+  update before the next ECHConfig change should be listed.
+- If `method` is `pkix(1)`, the server MUST have a valid
+  certificate (and chain) for the public name with the
+  critical `id-pe-echConfigSigning` extension (as defined
+  in {{iana}}) available at runtime to use for signing.
+  The certificate's public key algorithm dictates what
+  signature algorithms are possible.
 
 ## TLS Extensions for ECH Config Update
 
 ### EncryptedExtensions Delivery
 
-This specification reuses the ECH retry_configs delivery mechanism: the server sends an ECHConfigList where each ECHConfig contains the `ech_auth` extension with a signed authenticator. The server MAY include multiple ECHConfigs with different authentication methods (e.g., one with PKIX and one with RPK).
+This specification reuses the ECH retry_configs delivery
+mechanism: the server sends an ECHConfigList where each
+ECHConfig contains the `ech_auth` extension with a signed
+authenticator.  The server MAY include multiple ECHConfigs
+with different authentication methods (e.g., one with PKIX
+and one with RPK).
 
 ### Server Behavior
 
-When a server receives a ClientHello with the `encrypted_client_hello` extension, it processes ECH per {{!I-D.ietf-tls-esni}}. If the server has an updated ECHConfigList to distribute:
+When a server receives a ClientHello with the
+`encrypted_client_hello` extension, it processes ECH per
+{{!I-D.ietf-tls-esni}}.  If the server has an updated
+ECHConfigList to distribute:
 
-1. ECH Accepted: If the server successfully decrypts the ClientHelloInner, it completes the handshake using the inner ClientHello.
+1. ECH Accepted: If the server successfully decrypts the
+   ClientHelloInner, it completes the handshake using the
+   inner ClientHello.
 
-2. ECH Rejected: If the server cannot decrypt the ClientHelloInner, it SHOULD proceed with the outer handshake and include signed ECHConfigs in EncryptedExtensions. This allows the client to immediately retry with the correct configuration.
+2. ECH Rejected: If the server cannot decrypt the
+   ClientHelloInner, it SHOULD proceed with the outer
+   handshake and include signed ECHConfigs in
+   EncryptedExtensions.  This allows the client to
+   immediately retry with the correct configuration.
 
-The server may indicate that the client should attempt to retry without ECH by including an ECHAuth extension over an empty config.
+The server may indicate that the client should attempt to
+retry without ECH by producing a signature over a
+zero-length ECHConfigList.
 
 ### Client Behavior
 
-When a client retrieves an ECHConfig (e.g., from DNS), it examines the `ech_authinfo` extension and records:
+When a client retrieves an ECHConfig (e.g., from DNS), it
+examines the `ech_authinfo` extension and records:
 
 - The authentication `method` (RPK or PKIX)
 - Any `trusted_keys` for RPK validation
 
-During the TLS handshake, upon receiving an ECHConfigList in EE:
+During the TLS handshake, upon receiving an ECHConfigList
+in EncryptedExtensions:
 
-1. Validation: The client validates the authenticator according to its method:
-   - RPK: Computes the SHA-256 hash of the provided SPKI, verifies it matches one in `trusted_keys`, then verifies the signature
-   - PKIX: Validates the certificate chain, verifies the leaf certificate covers the ECHConfig's `public_name`, checks for the critical `id-pe-echConfigSigning` extension, then verifies the signature
+1. Validation: The client validates the authenticator
+   according to its method:
+   - RPK: Computes the SHA-256 hash of the provided SPKI,
+     verifies it matches one in `trusted_keys`, then
+     verifies the signature.
+   - PKIX: Validates the certificate chain, verifies the
+     leaf certificate covers the ECHConfig's
+     `public_name`, checks for the critical
+     `id-pe-echConfigSigning` extension, then verifies
+     the signature.
 
 2. Validity Checking: The client checks temporal validity:
-   - For RPK: Verifies current time is before `not_after`
-   - For PKIX: Verifies certificate validity period (the `not_after` field MUST be 0)
+   - For RPK: Verifies `not_after` is strictly greater
+     than the current time.
+   - For PKIX: Verifies the certificate validity period
+     and that `not_after` is strictly greater than the
+     current time.
 
-3. Installation and Retry (see Appendix A for state diagram):
-   - If validation succeeds and this was an ECH rejection (outer handshake):
-     * The client treats the retry_configs as authentic per {{I-D.ietf-tls-esni, Section 6.1.6}}
-     * The client MUST terminate the connection and retry with the new ECHConfig or without ECH if indicated by the server.
-     * The retry does not consider the server's TLS certificate for the public name
-   - If validation succeeds and this was an ECH acceptance:
-     * No changes to the ECH specification
+3. Installation and Retry (see {{appendix-a}} for state
+   diagram):
+   - If validation succeeds and this was an ECH rejection
+     (outer handshake):
+     * The client treats the retry_configs as authentic
+       per {{I-D.ietf-tls-esni}}.
+     * The client MUST terminate the connection and retry
+       with the new ECHConfig or without ECH if indicated
+       by the server.
+     * The retry does not consider the server's TLS
+       certificate for the public name.
+   - If validation succeeds and this was an ECH
+     acceptance:
+     * No changes to the ECH specification.
    - If validation fails:
-     * The client MUST treat this as if the server's TLS certificate could not be validated
-     * The client MUST NOT use the retry_configs
-     * The client terminates the connection without retry
+     * The client MUST treat this as if the server's TLS
+       certificate could not be validated.
+     * The client MUST NOT use the retry_configs.
+     * The client terminates the connection without retry.
 
-Note: Regardless of validation outcome in an ECH rejection, the client will terminate the current connection. The difference is whether it retries with the new configs (validation success) or treats it as a certificate validation failure (validation failure).
+Note: Regardless of validation outcome in an ECH
+rejection, the client will terminate the current
+connection.  The difference is whether it retries with the
+new configs (validation success) or treats it as a
+certificate validation failure (validation failure).
 
 ### Backward Compatibility
 
-Clients that do not implement this specification continue to process `retry_configs` as defined in {{!I-D.ietf-tls-esni}}, ignoring the authentication extensions. Servers that do not implement this specification send `retry_configs` as usual.
+Clients that do not implement this specification continue
+to process `retry_configs` as defined in
+{{!I-D.ietf-tls-esni}}, ignoring the authentication
+extensions.  Servers that do not implement this
+specification send `retry_configs` as usual.
 
 # Example Exchange
 
 ## Initial Setup
 
-Consider `api.example.com` as a service protected by ECH with public name `ech.example.net`. The operator publishes an ECHConfig via DNS HTTPS RR with the `ech_authinfo` extension containing:
+Consider `api.example.com` as a service protected by ECH
+with public name `ech.example.net`.  The operator publishes
+an ECHConfig via DNS HTTPS RR with the `ech_authinfo`
+extension containing:
 
-- Method: RPK (value 1)
-- Trusted keys: SHA-256 hash of an Ed25519 signing key's SPKI
+- Method: RPK (value 0)
+- Trusted keys: SHA-256 hash of an Ed25519 signing key's
+  SPKI
 
 ## Successful ECH
 
-This flow works identically to existing ECH
+This flow works identically to existing ECH.
 
 ## ECH Rejection with Recovery
 
@@ -306,7 +549,9 @@ This flow works identically to existing ECH
 2. Server rejects ECH: Cannot decrypt inner ClientHello
 3. Server continues outer handshake:
    - Sends signed ECHConfig in EncryptedExtensions
-   - Uses certificate for `foo.example.net`
+   - Uses certificate for `foo.example.net` (the client
+     does not validate this certificate; retry
+     authentication uses the signed ECHConfig)
 4. Client recovery:
    - Validates new ECHConfig
    - Closes connection
@@ -316,55 +561,119 @@ This flow works identically to existing ECH
 
 ## Passive Attackers
 
-This mechanism preserves ECH's protection against passive observation. ECHConfig updates are delivered within the EncryptedExtensions TLS message, preventing passive observers from learning about configuration changes. The mechanism ensures that even during retry scenarios, the client's intended server name is never exposed in cleartext.
+This mechanism preserves ECH's protection against passive
+observation.  ECHConfig updates are delivered within the
+EncryptedExtensions TLS message, preventing passive
+observers from learning about configuration changes.  The
+mechanism ensures that even during retry scenarios, the
+client's intended server name is never exposed in
+cleartext.
 
 ## Active Network Attackers
 
-The security of this mechanism fundamentally depends on the authenticity of the initial ECHConfig. If an attacker can inject a malicious initial configuration, the client's privacy is compromised, but their connections remain properly authenticated.
+The security of this mechanism fundamentally depends on the
+authenticity of the initial ECHConfig.  If an attacker can
+inject a malicious initial configuration, the client's
+privacy is compromised, but their connections remain
+properly authenticated.
 
-Initial retrieval of ECHConfigList via DNS is unchanged by this mechanism. This specification does not attempt to authenticate the initial DNS fetch. ECHConfigs obtained via HTTPS from a well-known URI benefit from Web PKI authentication. Pre-configured ECHConfigs in applications derive their trust from the application's distribution channel.
+Initial retrieval of ECHConfigList via DNS is unchanged by
+this mechanism.  This specification does not attempt to
+authenticate the initial DNS fetch.  ECHConfigs obtained
+via HTTPS from a well-known URI benefit from Web PKI
+authentication.  Pre-configured ECHConfigs in applications
+derive their trust from the application's distribution
+channel.
 
 ### Retry Configuration Integrity
 
-ECHConfigs delivered in EncryptedExtensions are usually protected by TLS 1.3's handshake encryption and integrity mechanisms. The Finished message ensures that any modification by an attacker would be detected. The authenticity of the Finished message is assured by validating the server's certificate chain, which the client checks is valid for the ECH Public Name.
+ECHConfigs delivered in EncryptedExtensions are usually
+protected by TLS 1.3's handshake encryption and integrity
+mechanisms.  The Finished message ensures that any
+modification by an attacker would be detected.  The
+authenticity of the Finished message is assured by
+validating the server's certificate chain, which the client
+checks is valid for the ECH Public Name.
 
-However, signed ECHConfigs don't benefit from this authentication because the client does not validate the server's certificate chain. Instead, the client verifies the ECHConfigs against the authenticator provided in the initial ECHConfig. This provides the same level of authenticity as checking the ECH Public Name would.
+However, signed ECHConfigs do not benefit from this
+authentication because the client does not validate the
+server's certificate chain.  Instead, the client verifies
+the ECHConfigs against the authenticator provided in the
+initial ECHConfig.  This provides the same level of
+authenticity as checking the ECH Public Name would.
 
-The inclusion of `not_after` timestamps (for RPK) or certificate validity periods (for PKIX) ensures configuration freshness. These temporal bounds prevent clients from accepting stale configurations that might use compromised keys or otherwise parameters. ECH providers should use a window of 24 hours.
+The inclusion of `not_after` timestamps (for RPK) or
+certificate validity periods (for PKIX) ensures
+configuration freshness.  These temporal bounds prevent
+clients from accepting stale configurations that might use
+compromised keys or outdated parameters.
 
 ### Key Management
 
-Servers MUST protect their ECH update signing keys. If an RPK signing key is compromised, the server SHOULD remove its hash from `trusted_keys`. Servers SHOULD including multiple keys in `trusted_keys` to facilitate key rotation and recovery from compromise.
+Servers MUST protect their ECH update signing keys.  If an
+RPK signing key is compromised, the server SHOULD remove
+its hash from `trusted_keys`.  Servers SHOULD include
+multiple keys in `trusted_keys` to facilitate key rotation
+and recovery from compromise.
 
-For PKIX-based updates, normal certificate lifecycle management applies. Servers SHOULD obtain new certificates before existing ones expire.
+For PKIX-based updates, normal certificate lifecycle
+management applies.  Servers SHOULD obtain new certificates
+before existing ones expire.
 
 ## Implementation Vulnerabilities
 
 ### Failure Handling
 
-ECH connection attempts with signed updates are handled identically to existing ECH connection attempts. The only difference is in how the server authenticates retry configurations, not how it responds to the success or failure of that authentication.
+ECH connection attempts with signed updates are handled
+identically to existing ECH connection attempts.  The only
+difference is in how the server authenticates retry
+configurations, not how it responds to the success or
+failure of that authentication.
 
-Algorithm agility is provided through the TLS SignatureScheme registry for RPK and standard PKIX certificate algorithms. Implementations SHOULD support commonly deployed algorithms and MUST be able to handle algorithm transitions.
+Algorithm agility is provided through the TLS
+SignatureScheme registry for RPK and standard PKIX
+certificate algorithms.  Implementations SHOULD support
+commonly deployed algorithms and MUST be able to handle
+algorithm transitions.
 
 ### Denial of Service Considerations
 
-The ECH Specification allows ECH Operators to decide which ECH extensions to attempt to decrypt based on the public ECHConfig ID advertised in the Client Hello and the public name. This extension reduces the value of thoses signals, depending on the ECH operator's chosen configurations, meaning that ECH operators may need to trial decrypt incoming ECH extensions.
+The ECH specification allows ECH operators to decide which
+ECH extensions to attempt to decrypt based on the public
+ECHConfig ID advertised in the ClientHello and the public
+name.  This extension reduces the value of those signals,
+depending on the ECH operator's chosen configurations,
+meaning that ECH operators may need to trial decrypt
+incoming ECH extensions.
 
-Attackers cannot force servers to send signed ECHConfigs without establishing TLS connections. Standard TLS denial-of-service mitigations (rate limiting, stateless cookies) apply equally to this mechanism.
+Attackers cannot force servers to send signed ECHConfigs
+without establishing TLS connections.  Standard TLS
+denial-of-service mitigations (rate limiting, stateless
+cookies) apply equally to this mechanism.
 
 # Privacy Considerations
 
-This specification introduces no new risks those already present in TLS and DNS when used with ECH.
+This specification introduces no new privacy risks beyond
+those already present in TLS and DNS when used with ECH.
+ECHConfig updates are delivered within encrypted TLS
+messages, preventing passive observers from learning about
+configuration changes.  Server-directed ECH disablement
+(signing an empty ECHConfigList) could degrade privacy if
+signing keys are compromised; clients SHOULD re-fetch
+ECHConfigs from DNS on subsequent connections to limit this
+exposure.
 
 # IANA Considerations {#iana}
 
 ## ECHConfig Extension
 
-IANA is requested to add the following entry to the "ECH Configuration Extension Type Values" registry:
+IANA is requested to add the following entries to the
+"ECH Configuration Extension Type Values" registry:
 
 - Extension Name: `ech_authinfo`
 - Value: TBD1
-- Purpose: Conveys supported authentication methods and trusted keys
+- Purpose: Conveys supported authentication methods and
+  trusted keys
 - Reference: This document
 
 - Extension Name: `ech_auth`
@@ -374,17 +683,25 @@ IANA is requested to add the following entry to the "ECH Configuration Extension
 
 ## X.509 Certificate Extension OID
 
-IANA is requested to allocate an object identifier (OID) under the "SMI Security for PKIX Certificate Extensions (1.3.6.1.5.5.7.1)" registry with the following values:
+IANA is requested to allocate an object identifier (OID)
+under the "SMI Security for PKIX Certificate Extensions
+(1.3.6.1.5.5.7.1)" registry with the following values:
 
 - OID: id-pe-echConfigSigning (1.3.6.1.5.5.7.1.TBD2)
 - Name: ECH Configuration Signing
-- Description: Indicates that the certificate's subject public key is authorized to sign ECH configuration updates for the DNS names in the certificate's Subject Alternative Name (SAN).
-- Criticality: Certificates containing this extension MUST mark it critical.
+- Description: Indicates that the certificate's subject
+  public key is authorized to sign ECH configuration
+  updates for the DNS names in the certificate's Subject
+  Alternative Name (SAN).
+- Criticality: Certificates containing this extension
+  MUST mark it critical.
 - Reference: This document.
 
 ## ECH Authentication Methods Registry
 
-IANA is requested to establish a new registry called "ECH Authentication Methods" with the following initial values:
+IANA is requested to establish a new registry called
+"ECH Authentication Methods" with the following initial
+values:
 
 | Value | Method     | Description                                  | Reference      |
 |-------|------------|----------------------------------------------|----------------|
@@ -398,17 +715,84 @@ New values are assigned via IETF Review.
 
 ## Method Selection
 
-Operators SHOULD support at least one widely implemented method. PKIX (critical extension) provides easier operational deployment with standard certificate issuance workflows. RPK offers small artifacts and simple verification but must the list of hashed keys and those used for signing must be carefully kept in sync.
+Operators SHOULD support at least one widely implemented
+method.  PKIX (critical extension) provides easier
+operational deployment with standard certificate issuance
+workflows.  RPK offers small artifacts and simple
+verification but the list of hashed keys and those used for
+signing must be carefully kept in sync.
 
 ## Size Considerations
 
-When sending signed ECHConfigs in EncryptedExtensions, servers should be mindful of message size to avoid fragmentation or exceeding anti-amplification limits. RPK signatures are typically more compact than PKIX certificate chains.
+When sending signed ECHConfigs in EncryptedExtensions,
+servers SHOULD be mindful of message size to avoid
+fragmentation or exceeding anti-amplification limits.  RPK
+signatures are typically more compact than PKIX certificate
+chains.
 
 ## Key Rotation
 
-Publish updates well in advance of key retirement. Include appropriate validity periods for each method. Consider overlapping validity windows to allow graceful client migration.
+Operators SHOULD publish updates well in advance of key
+retirement.  Include appropriate validity periods for each
+method.  Consider overlapping validity windows to allow
+graceful client migration.
+
+--- back
+
+# Client Retry State Diagram {#appendix-a}
+
+The following diagram shows client behavior upon receiving
+retry_configs in EncryptedExtensions.  "ech_auth" refers
+to the authentication extension within the delivered
+ECHConfig.
+
+~~~~
+    Receive retry_configs in EE
+                |
+                v
+      +-------------------+
+      | ech_auth present? |
+      +-------------------+
+         |             |
+        yes            no
+         |             |
+         v             v
+    +-----------+   Process per base
+    | Validate  |   ECH spec (no
+    | ech_auth  |   authentication)
+    +-----------+
+         |
+    +----+----+
+    |         |
+  valid    invalid
+    |         |
+    v         v
+  +-----+  Treat as certificate
+  | ECH |  validation failure;
+  | out |  terminate connection;
+  | come|  do not retry.
+  | ?   |
+  +-----+
+    |    \
+ rejected  accepted
+    |        \
+    v         v
+  +--------+ Continue handshake
+  |Config  | normally (no change
+  |empty?  | to ECH spec).
+  +--------+
+    |     \
+   no     yes (zero-length)
+    |       \
+    v        v
+  Terminate  Terminate connection;
+  connection; MUST NOT attempt ECH
+  retry with  on retry; SHOULD
+  new config. clear cached config.
+~~~~
+{: #fig-retry title="Client Retry State Diagram"}
 
 # Acknowledgments
 
-The authors thank Martin Thomson for earlier contributions and discussions on the initial draft.
-
+The authors thank Martin Thomson for earlier contributions
+and discussions on the initial draft.

--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -89,7 +89,7 @@ ECHConfigList:
 : A sequence of one or more ECHConfig structures as defined in ECH (a byte string that starts with a 16-bit length and may contain multiple concatenated ECHConfig values).
 
 ECHConfigTBS (To-Be-Signed):
-: The serialized ECHConfig structure with the `ech_auth` extension, but with the `signature` field within `ech_auth` set to zero-length. This includes all ECHConfig fields and the `ech_auth` extension's `method` and `trusted_keys` fields.
+: The serialized ECHConfig structure with the `ech_auth` extension, but with the `signature` field within `ech_auth.signature` set to zero-length. This includes all ECHConfig fields and the `ech_auth` extension's `method` and `trusted_keys` fields.
 
 signed ECHConfig:
 : An ECHConfig that contains an `ech_auth` extension with a valid signature in the `signature` field, allowing clients to verify its authenticity.
@@ -198,8 +198,8 @@ The signature is computed over the concatenation:
 where:
 
 - `ECHConfigTBS` (To-Be-Signed) is the serialized ECHConfig structure including
-  the `ech_auth` extension, but with the `signature` field within `ech_auth`
-  set to zero-length. This means it includes:
+  the `ech_auth` extension, but with the `signature` field within `ech_auth.signature`
+  set to zero-length. This means `ECHConfigTBS` includes:
   - All ECHConfig base fields (version, length, contents, etc.)
   - All extensions including `ech_auth` (which MUST be last)
   - Within `ech_auth`: the `method`, and the authenticator/

--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -174,7 +174,7 @@ The `ech_auth` and`ech_authinfo` extensions have the following structure:
     // For now, implementations MUST use sha256(4). Future specs may allow others.
     opaque SPKIHash<32..32>;  // SHA-256 hash of DER-encoded SPKI
 
-struct {
+    struct {
       ECHAuthMethod method;              // Single authentication method
       SPKIHash trusted_keys<0..2^16-1>;  // RPK-only; SHA-256 hashes per IANA TLS
     } ECHAuthInfo;


### PR DESCRIPTION
## Summary

Cherry-picks and consolidates changes from open PRs, plus review feedback fixes:

- Cherry-picks from #2 (@dennisjackson): general tidyup and nits
- Cherry-picks from #3 (@bwesterb): fix formatting of struct definitions
- Cherry-picks from #4 (@bwesterb): disambiguate between signature

Additional fixes addressing review comments on #2:
- Fix ECHAuth struct syntax (type name, semicolons, indentation)
- Update ECHConfigTBS definition for ech_auth/ech_authinfo split
- Add rationale for excluding trusted_keys from signature
- Add not_after replay window guidance (24h RECOMMENDED)
- Formalize server-directed ECH disablement (zero-length ECHConfigList)
- Align PKIX not_after with RPK (strictly greater than current time)
- Expand Privacy Considerations for signed empty config risk
- Fix contractions, typos, and missing spaces throughout
- Add Alessandro Ghedini as author

Supersedes #2, #3, #4.

cc @dennisjackson @bwesterb for review