### PR TITLE
Clarify outer handshake certificate behavior during ECH rejection

### DIFF
--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -459,6 +459,17 @@ ECHConfigList to distribute:
    EncryptedExtensions.  This allows the client to
    immediately retry with the correct configuration.
 
+   The server sends a Certificate message as part of the
+   outer handshake, but the certificate does not need to
+   be valid for the ECHConfig's `public_name`.  The
+   server MAY use any certificate, including its default
+   certificate or a certificate for the origin server
+   name.  When this specification is in use, the outer
+   handshake serves as an encrypted and
+   integrity-protected transport for the signed retry
+   configs; the client does not rely on the server's
+   certificate for authentication of the retry configs.
+
 The server may indicate that the client should attempt to
 retry without ECH by producing a signature over a
 zero-length ECHConfigList.
@@ -498,11 +509,13 @@ in EncryptedExtensions:
      (outer handshake):
      * The client treats the retry_configs as authentic
        per {{I-D.ietf-tls-esni}}.
+     * Because the `ech_auth` signature establishes
+       authenticity of the retry configs, the client does
+       not need to validate the server's Certificate
+       message in the outer handshake.
      * The client MUST terminate the connection and retry
        with the new ECHConfig or without ECH if indicated
        by the server.
-     * The retry does not consider the server's TLS
-       certificate for the public name.
    - If validation succeeds and this was an ECH
      acceptance:
      * No changes to the ECH specification.
@@ -587,20 +600,25 @@ channel.
 
 ### Retry Configuration Integrity
 
-ECHConfigs delivered in EncryptedExtensions are usually
-protected by TLS 1.3's handshake encryption and integrity
-mechanisms.  The Finished message ensures that any
-modification by an attacker would be detected.  The
-authenticity of the Finished message is assured by
-validating the server's certificate chain, which the client
-checks is valid for the ECH Public Name.
+In the base ECH specification, retry configs in
+EncryptedExtensions are authenticated by the server's TLS
+certificate for the public name.  This specification
+replaces that certificate-based authentication with the
+`ech_auth` signature.
 
-However, signed ECHConfigs do not benefit from this
-authentication because the client does not validate the
-server's certificate chain.  Instead, the client verifies
-the ECHConfigs against the authenticator provided in the
-initial ECHConfig.  This provides the same level of
-authenticity as checking the ECH Public Name would.
+The outer handshake still provides confidentiality and
+integrity protection for the retry configs.
+EncryptedExtensions is encrypted with the handshake
+traffic key, and the Finished message ensures that any
+modification by an active attacker would be detected.
+However, because the client does not validate the
+server's certificate, an active attacker could establish
+the outer handshake with the client while forwarding
+legitimate signed retry configs obtained from the real
+server.  This is not a security concern: the retry
+configs are independently authenticated by the `ech_auth`
+signature, and the client does not send application data
+during the outer handshake when ECH is rejected.
 
 The inclusion of `not_after` timestamps (for RPK) or
 certificate validity periods (for PKIX) ensures


### PR DESCRIPTION
## Summary

- Clarify that the server's Certificate in the outer handshake does not need to be valid for the ECHConfig `public_name` when `ech_auth` is in use
- Specify that the client skips certificate validation when `ech_auth` validation succeeds
- Rewrite Retry Configuration Integrity security considerations to clearly distinguish integrity (from TLS handshake) and authenticity (from `ech_auth` signature)

## Changes

**Server Behavior**: Added paragraph explaining the server MAY use any certificate in the outer handshake -- the outer handshake serves as encrypted transport for the signed retry configs.

**Client Behavior**: Added bullet under successful validation clarifying that certificate validation is unnecessary because `ech_auth` establishes authenticity.

**Security Considerations**: Rewrote to note that an active attacker forwarding legitimate signed configs via a MitM'd outer handshake is not a concern, since configs are independently authenticated and no application data is sent.
