### PR TITLE
Clarify that the outer-handshake certificate need not match the public name

### DIFF
--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -368,6 +368,14 @@ When a server receives a ClientHello with the
    EncryptedExtensions.  This allows the client to
    immediately retry with the correct configuration.
 
+The server sends a Certificate message as part of the outer handshake,
+but the certificate need not be valid for the ECHConfig's `public_name`.
+The server MAY use any certificate, including its default certificate or
+one for the origin server name.  The client does not rely on the
+server's certificate to authenticate the retry configurations; the outer
+handshake serves only as an encrypted, integrity-protected transport for
+the signed configurations.
+
 The server may indicate that the client should attempt to
 retry without ECH by setting `disable` to `1` in a
 signed `ech_auth` extension.


### PR DESCRIPTION
Consolidates the still-relevant content from the remaining open PRs onto current main (post-#17, RPK-only) so the queue can be cleared.

## Carried forward
- **#15** (Clarify outer handshake certificate behavior): the Server Behavior paragraph stating that the outer-handshake certificate need not be valid for the `public_name`, and that the client does not rely on it to authenticate the retry configs. Rewritten against the RPK-only text and wrapped to the project line-width rule. The rest of #15 (Client Behavior, Retry Configuration Integrity) is already covered by #17 and the merged #18.

## Reviewed, not carried (superseded by #17's PKIX removal)
- **#2** (General tidyup, @dennisjackson): the abstract/intro/terminology improvements are already in main via #14/#17; the remaining text still references PKIX and the two-method model.
- **#3** (fix formatting of struct definitions, @bwesterb): reformats the old `ECHAuthMethod` struct that #17 replaced with the flat RPK-only `ECHAuth`.
- **#4** (Disambiguate between signature, @bwesterb): disambiguates a nested `signature.signature` that #17 flattened away; no longer applicable.

Closing #15, #2, #3, and #4 in favor of this PR.

Line widths verified with the safe-spec over/under check; `make` builds clean.
