### PR TITLE
Pre-submission review fixes (signed-ECH -02)

### DIFF
--- a/draft-sullivan-tls-signed-ech-updates.md
+++ b/draft-sullivan-tls-signed-ech-updates.md
@@ -317,15 +317,16 @@ replayed configurations.  A window of 24 hours is
 RECOMMENDED as a balance between operational simplicity
 and replay resistance.
 
-The `spki` field contains the DER-encoded
-SubjectPublicKeyInfo of the signing key.  The client MUST
-compute the SHA-256 hash of `spki`, verify that it matches
-one of the hashes in `trusted_keys`, check that the
-current time is before the `not_after` timestamp, and then
-verify the signature with the public key in `spki`.  The
-`not_after` field is REQUIRED and MUST be a timestamp
-strictly greater than the client's current time at
-verification.
+The `spki` field contains the DER-encoded SubjectPublicKeyInfo of the
+signing key.  The client MUST compute the SHA-256 hash of `spki`, verify
+that it matches one of the hashes in `trusted_keys`, check that the
+current time is before the `not_after` timestamp, and then verify the
+signature with the public key in `spki`.  The `not_after` field is
+REQUIRED and MUST be a timestamp strictly greater than the client's
+current time at verification.  Because this check is strict and uses the
+client's local clock, operators SHOULD provision `not_after` with enough
+margin to accommodate reasonable client clock skew (on the order of
+minutes).
 
 The `algorithm` field is a `SignatureScheme` value from
 {{!RFC8446}}.  The client MUST verify that `algorithm` is
@@ -506,11 +507,15 @@ cleartext.
 
 ## Active Network Attackers
 
-The security of this mechanism fundamentally depends on the
-authenticity of the initial ECHConfig.  If an attacker can
-inject a malicious initial configuration, the client's
-privacy is compromised, but their connections remain
-properly authenticated.
+The security of this mechanism fundamentally depends on the authenticity
+of the initial ECHConfig.  If an attacker can inject a malicious initial
+configuration, the client's privacy is compromised, but their
+connections remain properly authenticated.
+
+On ECH rejection, the client sends no application data over the outer
+handshake, so an attacker that presents a forged or unvalidatable retry
+configuration extracts nothing from the client beyond what the rejection
+itself reveals.
 
 Initial retrieval of ECHConfigList via DNS is unchanged by
 this mechanism.  This specification does not attempt to
@@ -614,13 +619,15 @@ transitions.
 
 ### Denial of Service Considerations
 
-The ECH specification allows ECH operators to decide which
-ECH extensions to attempt to decrypt based on the public
-ECHConfig ID advertised in the ClientHello and the public
-name.  This extension reduces the value of those signals,
-depending on the ECH operator's chosen configurations,
-meaning that ECH operators may need to trial decrypt
-incoming ECH extensions.
+The ECH specification allows ECH operators to decide which ECH
+extensions to attempt to decrypt based on the public ECHConfig ID
+advertised in the ClientHello and the public name.  Deployments of this
+mechanism that vary the public name (for example, per-client public
+names) weaken the public name as a routing signal.  This is an
+operational routing tradeoff rather than a protocol mechanism: an
+operator that chooses such configurations must select candidate
+configurations using the remaining signals, such as the config ID, and
+accept the processing cost of decryption attempts that do not succeed.
 
 Attackers cannot force servers to send signed ECHConfigs
 without establishing TLS connections.  Standard TLS


### PR DESCRIPTION
Editorial pass ahead of the -02 submission on 2026-07-06.

## Applied

1. Active Network Attackers: added an explicit sentence that on ECH
   rejection the client sends no application data over the outer
   handshake, so a forged or unvalidatable retry configuration
   extracts nothing from the client beyond what the rejection itself
   reveals.
2. Denial of Service Considerations: rewrote the "operators may need
   to trial decrypt" text.  The consequence of varying the public
   name is now scoped as an operational routing tradeoff (operators
   route on the remaining signals such as the config ID and accept
   the cost of failed decryption attempts), removing the implication
   that trial decryption is a defined protocol fallback.
3. Signature Computation: added one sentence of clock-skew guidance
   for the strict `not_after` > now check (operators SHOULD provision
   `not_after` with margin, on the order of minutes, for client clock
   skew).

## Flagged for author/WG decision

No text changed for these; both are design/wire changes.

(a) The signed `to_be_signed` (context label plus ECHConfigTBS,
Section "Signature Computation") has no domain separation beyond the
context label.  Cross-domain replay of a signed configuration is
prevented only by the SHOULD-level guidance to use a separate signing
key per isolation domain (Security Considerations, "Replay and
Freshness of Signed Configurations").  Folding the `public_name` or a
hash of the initial ECHConfig into the TBS would bind a retry
configuration to the configuration it updates, but is a wire change.

(b) `trusted_keys` pins only the SHA-256 SPKI hash.  Pinning the
`SignatureScheme` alongside the SPKI hash would prevent an attacker
from using a trusted key with a weaker algorithm the key type also
admits, but changes the `ECHAuthInfo` wire format.
